### PR TITLE
feat: updating instead of overwriting mako config

### DIFF
--- a/community/sway/etc/sway/config.d/92-enable-mako-theme.conf
+++ b/community/sway/etc/sway/config.d/92-enable-mako-theme.conf
@@ -1,4 +1,5 @@
 exec_always {
-  '[ -f "$HOME/.config/mako/config" ] && sed -i -e "/border-color/c border-color=ACCENT_COLOR" -e "/text-color/c text-color=TEXT_COLOR" -e "/font/c font=TERM_FONT" -e "/background-color/c background-color=BACKGROUND_COLOR" $HOME/.config/mako/config && sed -i -e $theme_template_script $HOME/.config/mako/config'
-  '[ ! -f "$HOME/.config/mako/config" ] && mkdir -p $HOME/.config/mako && cat /usr/share/sway/themes/templates/mako | sed -e $theme_template_script > $HOME/.config/mako/config'
+  '[ ! -f "$HOME/.config/mako/config" ] && mkdir -p $HOME/.config/mako && cat /usr/share/sway/themes/templates/mako > $HOME/.config/mako/config'
+  'sed -i -e "/border-color/c border-color=ACCENT_COLOR" -e "/text-color/c text-color=TEXT_COLOR" -e "/font/c font=TERM_FONT" -e "/background-color/c background-color=BACKGROUND_COLOR" $HOME/.config/mako/config'
+  'sed -i -e $theme_template_script $HOME/.config/mako/config'
 }

--- a/community/sway/etc/sway/config.d/92-enable-mako-theme.conf
+++ b/community/sway/etc/sway/config.d/92-enable-mako-theme.conf
@@ -1,3 +1,4 @@
 exec_always {
-  'mkdir -p $HOME/.config/mako && cat /usr/share/sway/themes/templates/mako | sed -e $theme_template_script > $HOME/.config/mako/config'
+  '[ -f "$HOME/.config/mako/config" ] && sed -i -e "/border-color/c border-color=ACCENT_COLOR" -e "/text-color/c text-color=TEXT_COLOR" -e "/font/c font=TERM_FONT" -e "/background-color/c background-color=BACKGROUND_COLOR" $HOME/.config/mako/config && sed -i -e $theme_template_script $HOME/.config/mako/config'
+  '[ ! -f "$HOME/.config/mako/config" ] && mkdir -p $HOME/.config/mako && cat /usr/share/sway/themes/templates/mako | sed -e $theme_template_script > $HOME/.config/mako/config'
 }


### PR DESCRIPTION
Instead of replacing the mako config file each time this updates just the colors and fonts in the file.  It only copies the template file if no config file exist.

closes https://github.com/Manjaro-Sway/manjaro-sway/issues/66