### PR TITLE
fix: argument to grimshot

### DIFF
--- a/community/sway/etc/sway/modes/screenshot
+++ b/community/sway/etc/sway/modes/screenshot
@@ -24,7 +24,7 @@ mode --pango_markup $mode_screenshot {
     
     # User can pick the area to screenshot
     bindsym a exec $grimshot --notify copy area
-    bindsym Shift+a exec $grimshot --notify area output
+    bindsym Shift+a exec $grimshot --notify save area
 
     # Return to default mode.
     bindsym Escape mode "default"


### PR DESCRIPTION
It seems like there is a bug when picking an area and saving the screenshot as a file.
Changing the argument to grimshot fixes the problem.