### PR TITLE
Add definitions for --to-code and use it by default

### DIFF
--- a/community/sway/etc/sway/definitions
+++ b/community/sway/etc/sway/definitions
@@ -9,6 +9,14 @@ set $down j
 set $up k
 set $right l
 
+
+# Add --to-code to bindsym, support for non-latin layouts
+set $bindsym bindsym --to-code
+
+# For user's convenience, the same for unbindsym
+set $unbindsym unbindsym --to-code
+
+
 # background
 set $background /usr/share/backgrounds/manjaro-sway/gruvbox-dark-manjarosway-3840x2160.png
 

--- a/community/sway/etc/sway/modes/default
+++ b/community/sway/etc/sway/modes/default
@@ -3,13 +3,13 @@
 # Basics:
 #
 ## Launch // Terminal ##
-bindsym $mod+Return exec $term
+$bindsym $mod+Return exec $term
 
 ## Action // Kill focused window ##
-bindsym $mod+Shift+q kill
+$bindsym $mod+Shift+q kill
 
 ## Launch // Launcher ##
-bindsym $mod+d exec $menu
+$bindsym $mod+d exec $menu
 
 # Drag floating windows by holding down $mod and left mouse button.
 # Resize them with right mouse button + $mod.
@@ -19,102 +19,102 @@ bindsym $mod+d exec $menu
 floating_modifier $mod normal
 
 ## Action // Reload Sway Configuration ##
-bindsym $mod+Shift+c reload
+$bindsym $mod+Shift+c reload
 
 ## Launch // Exit Menu ##
-bindsym $mod+Shift+e exec $shutdown
+$bindsym $mod+Shift+e exec $shutdown
 
 ## Action // Increase volume of Master ##
-bindsym XF86AudioRaiseVolume exec $onscreen_bar $(amixer sset Master 5%+ | sed -En 's/.*\[([0-9]+)%\].*/\1/p' | head -1) $base0C
+$bindsym XF86AudioRaiseVolume exec $onscreen_bar $(amixer sset Master 5%+ | sed -En 's/.*\[([0-9]+)%\].*/\1/p' | head -1) $base0C
 
 ## Action // Decrease volume of Master ##
-bindsym XF86AudioLowerVolume exec $onscreen_bar $(amixer sset Master 5%- | sed -En 's/.*\[([0-9]+)%\].*/\1/p' | head -1) $base0C
+$bindsym XF86AudioLowerVolume exec $onscreen_bar $(amixer sset Master 5%- | sed -En 's/.*\[([0-9]+)%\].*/\1/p' | head -1) $base0C
 
 ## Action // Mute volume of Master ##
-bindsym XF86AudioMute exec $onscreen_bar $(amixer sset Master toggle | sed -En '/\[on\]/ s/.*\[([0-9]+)%\].*/\1/ p; /\[off\]/ s/.*/0/p' | head -1) $base0C
+$bindsym XF86AudioMute exec $onscreen_bar $(amixer sset Master toggle | sed -En '/\[on\]/ s/.*\[([0-9]+)%\].*/\1/ p; /\[off\]/ s/.*/0/p' | head -1) $base0C
 
 ## Action // Increase brightness ##
-bindsym XF86MonBrightnessUp exec light -A 5 && $onscreen_bar $(light -G | cut -d'.' -f1) $base0C
+$bindsym XF86MonBrightnessUp exec light -A 5 && $onscreen_bar $(light -G | cut -d'.' -f1) $base0C
 
 ## Action // Decrease brightness ##
-bindsym XF86MonBrightnessDown exec light -U 5 && $onscreen_bar $(light -G | cut -d'.' -f1) $base0C
+$bindsym XF86MonBrightnessDown exec light -U 5 && $onscreen_bar $(light -G | cut -d'.' -f1) $base0C
 
-bindsym XF86PowerOff exec $shutdown
+$bindsym XF86PowerOff exec $shutdown
 
-bindsym XF86TouchpadToggle input type:touchpad events toggle enabled disabled
+$bindsym XF86TouchpadToggle input type:touchpad events toggle enabled disabled
 
 #
 # Moving around:
 #
 # Move your focus around
 ## Navigation // Move focus // $mod + ↑ ↓ ← → ##
-bindsym $mod+Left focus left
-bindsym $mod+Down focus down
-bindsym $mod+Up focus up
-bindsym $mod+Right focus right
+$bindsym $mod+Left focus left
+$bindsym $mod+Down focus down
+$bindsym $mod+Up focus up
+$bindsym $mod+Right focus right
 
 ## Navigation // Move focussed window // $mod + Shift + ↑ ↓ ← → ##
-bindsym $mod+Shift+Left move left
-bindsym $mod+Shift+Down move down
-bindsym $mod+Shift+Up move up
-bindsym $mod+Shift+Right move right
+$bindsym $mod+Shift+Left move left
+$bindsym $mod+Shift+Down move down
+$bindsym $mod+Shift+Up move up
+$bindsym $mod+Shift+Right move right
 
 #
 # Workspaces:
 #
 ## Navigation // Switch workspace // $mod + [number] ##
-bindsym $mod+1 workspace $ws1
-bindsym $mod+2 workspace $ws2
-bindsym $mod+3 workspace $ws3
-bindsym $mod+4 workspace $ws4
-bindsym $mod+5 workspace $ws5
-bindsym $mod+6 workspace $ws6
-bindsym $mod+7 workspace $ws7
-bindsym $mod+8 workspace $ws8
-bindsym $mod+9 workspace $ws9
-bindsym $mod+0 workspace $ws10
+$bindsym $mod+1 workspace $ws1
+$bindsym $mod+2 workspace $ws2
+$bindsym $mod+3 workspace $ws3
+$bindsym $mod+4 workspace $ws4
+$bindsym $mod+5 workspace $ws5
+$bindsym $mod+6 workspace $ws6
+$bindsym $mod+7 workspace $ws7
+$bindsym $mod+8 workspace $ws8
+$bindsym $mod+9 workspace $ws9
+$bindsym $mod+0 workspace $ws10
 
 ## Action // Move focussed window to workspace // $mod + Shift + [number] ##
-bindsym $mod+Shift+1 move container to workspace $ws1
-bindsym $mod+Shift+2 move container to workspace $ws2
-bindsym $mod+Shift+3 move container to workspace $ws3
-bindsym $mod+Shift+4 move container to workspace $ws4
-bindsym $mod+Shift+5 move container to workspace $ws5
-bindsym $mod+Shift+6 move container to workspace $ws6
-bindsym $mod+Shift+7 move container to workspace $ws7
-bindsym $mod+Shift+8 move container to workspace $ws8
-bindsym $mod+Shift+9 move container to workspace $ws9
-bindsym $mod+Shift+0 move container to workspace $ws10
+$bindsym $mod+Shift+1 move container to workspace $ws1
+$bindsym $mod+Shift+2 move container to workspace $ws2
+$bindsym $mod+Shift+3 move container to workspace $ws3
+$bindsym $mod+Shift+4 move container to workspace $ws4
+$bindsym $mod+Shift+5 move container to workspace $ws5
+$bindsym $mod+Shift+6 move container to workspace $ws6
+$bindsym $mod+Shift+7 move container to workspace $ws7
+$bindsym $mod+Shift+8 move container to workspace $ws8
+$bindsym $mod+Shift+9 move container to workspace $ws9
+$bindsym $mod+Shift+0 move container to workspace $ws10
 
 #
 # Layout stuff:
 #
 ## Setting // Split windows horizontally ##
-bindsym $mod+b splith
+$bindsym $mod+b splith
 ## Setting // Split windows vertically ##
-bindsym $mod+v splitv
+$bindsym $mod+v splitv
 
 ## Action // Switch to window stacking ##
-bindsym $mod+s layout stacking
+$bindsym $mod+s layout stacking
 ## Action // Switch to window tabbing ##
-bindsym $mod+w layout tabbed
+$bindsym $mod+w layout tabbed
 ## Action // Toggle window splitting ##
-bindsym $mod+e layout toggle split
+$bindsym $mod+e layout toggle split
 
 ## Action // Toggle fullscreen ##
-bindsym $mod+f fullscreen
+$bindsym $mod+f fullscreen
 
 ## Action // Toggle floating ##
-bindsym $mod+Shift+space floating toggle
+$bindsym $mod+Shift+space floating toggle
 
 ## Navigation // Swap focus between the tiling area and the floating area ##
-bindsym $mod+space focus mode_toggle
+$bindsym $mod+space focus mode_toggle
 
 ## Navigation // Swap focus to the parent window ##
-bindsym $mod+a focus parent
+$bindsym $mod+a focus parent
 
 ## Launch // Help ##
-bindsym $mod+question exec $help
+$bindsym $mod+question exec $help
 
 default_border pixel 1
 hide_edge_borders smart

--- a/community/sway/etc/sway/modes/recording
+++ b/community/sway/etc/sway/modes/recording
@@ -11,24 +11,24 @@ set $mode_recording_on "<span foreground='$base0A'>壘</span>  \
 <span foreground='$base05'><b>Exit</b></span> <span foreground='$base0A'>(<b>ESC</b>)</span>"
 
 mode --pango_markup $mode_recording_on {
-    bindsym Escape exec killall -s SIGINT wf-recorder, mode "default"
+    $bindsym Escape exec killall -s SIGINT wf-recorder, mode "default"
 }
 
 mode --pango_markup $mode_recording {
-    bindsym w exec killall -s SIGINT wf-recorder || wf-recorder --audio=0 -o $(swaymsg -t get_outputs | jq -r '.[] | select(.focused) | .name') \
+    $bindsym w exec killall -s SIGINT wf-recorder || wf-recorder --audio=0 -o $(swaymsg -t get_outputs | jq -r '.[] | select(.focused) | .name') \
             -f ~/Videos/recording-$(date +'%Y-%m-%d-%H%M%S').mp4, mode $mode_recording_on
-    bindsym Shift+w exec killall -s SIGINT wf-recorder || wf-recorder --audio -o $(swaymsg -t get_outputs | jq -r '.[] | select(.focused) | .name') \
+    $bindsym Shift+w exec killall -s SIGINT wf-recorder || wf-recorder --audio -o $(swaymsg -t get_outputs | jq -r '.[] | select(.focused) | .name') \
             -f ~/Videos/recording-$(date +'%Y-%m-%d-%H%M%S').mp4, mode $mode_recording_on
-    bindsym r exec killall -s SIGINT wf-recorder || wf-recorder --audio=0 -g "$(slurp -d)" \
+    $bindsym r exec killall -s SIGINT wf-recorder || wf-recorder --audio=0 -g "$(slurp -d)" \
             -f ~/Videos/recording-$(date +'%Y-%m-%d-%H%M%S').mp4, mode $mode_recording_on
-    bindsym Shift+r exec killall -s SIGINT wf-recorder || wf-recorder --audio -g "$(slurp -d)" \
+    $bindsym Shift+r exec killall -s SIGINT wf-recorder || wf-recorder --audio -g "$(slurp -d)" \
             -f ~/Videos/recording-$(date +'%Y-%m-%d-%H%M%S').mp4, mode $mode_recording_on
 
     # Return to default mode.
-    bindsym Escape mode "default"
-    bindsym Return mode "default"
+    $bindsym Escape mode "default"
+    $bindsym Return mode "default"
 }
 
 ## Launch // Recording Mode ##
-bindsym $mod+Shift+r mode $mode_recording
+$bindsym $mod+Shift+r mode $mode_recording
 

--- a/community/sway/etc/sway/modes/resize
+++ b/community/sway/etc/sway/modes/resize
@@ -10,34 +10,34 @@ mode --pango_markup $mode_resize {
     # right will grow the containers width
     # up will shrink the containers height
     # down will grow the containers height
-    bindsym $left resize shrink width 10px
-    bindsym $down resize grow height 10px
-    bindsym $up resize shrink height 10px
-    bindsym $right resize grow width 10px
-    bindsym Shift+$left resize shrink width 20px
-    bindsym Shift+$down resize grow height 20px
-    bindsym Shift+$up resize shrink height 20px
-    bindsym Shift+$right resize grow width 20px
+    $bindsym $left resize shrink width 10px
+    $bindsym $down resize grow height 10px
+    $bindsym $up resize shrink height 10px
+    $bindsym $right resize grow width 10px
+    $bindsym Shift+$left resize shrink width 20px
+    $bindsym Shift+$down resize grow height 20px
+    $bindsym Shift+$up resize shrink height 20px
+    $bindsym Shift+$right resize grow width 20px
 
     # Ditto, with arrow keys
-    bindsym Left resize shrink width 10px
-    bindsym Down resize grow height 10px
-    bindsym Up resize shrink height 10px
-    bindsym Right resize grow width 10px
-    bindsym Shift+Left resize shrink width 20px
-    bindsym Shift+Down resize grow height 20px
-    bindsym Shift+Up resize shrink height 20px
-    bindsym Shift+Right resize grow width 20px
+    $bindsym Left resize shrink width 10px
+    $bindsym Down resize grow height 10px
+    $bindsym Up resize shrink height 10px
+    $bindsym Right resize grow width 10px
+    $bindsym Shift+Left resize shrink width 20px
+    $bindsym Shift+Down resize grow height 20px
+    $bindsym Shift+Up resize shrink height 20px
+    $bindsym Shift+Right resize grow width 20px
 
     ## Resize // Window Gaps // + - ##
-    bindsym minus gaps inner current minus 5px
-    bindsym plus gaps inner current plus 5px
+    $bindsym minus gaps inner current minus 5px
+    $bindsym plus gaps inner current plus 5px
 
     # Return to default mode
-    bindsym Return mode "default"
-    bindsym Escape mode "default"
+    $bindsym Return mode "default"
+    $bindsym Escape mode "default"
 }
 ## Launch // Resize Mode ##
-bindsym $mod+r mode $mode_resize
+$bindsym $mod+r mode $mode_resize
 gaps inner 5px
 gaps outer 5px

--- a/community/sway/etc/sway/modes/scratchpad
+++ b/community/sway/etc/sway/modes/scratchpad
@@ -5,8 +5,8 @@
 # You can send windows there and get them back later.
 
 ## Action // Move the currently focused window to the scratchpad ##
-bindsym $mod+Shift+minus move scratchpad
+$bindsym $mod+Shift+minus move scratchpad
 
 # If there are multiple scratchpad windows, this command cycles through them.
 ## Action // Show the next scratchpad window or hide the focused scratchpad window. ##
-bindsym $mod+minus scratchpad show
+$bindsym $mod+minus scratchpad show

--- a/community/sway/etc/sway/modes/screenshot
+++ b/community/sway/etc/sway/modes/screenshot
@@ -12,24 +12,24 @@ set $grimshot /usr/share/sway/scripts/grimshot
 mode --pango_markup $mode_screenshot {
 
     # screen = all outputs
-    bindsym e exec $grimshot --notify copy screen
-    bindsym Shift+e exec $grimshot --notify save screen
+    $bindsym e exec $grimshot --notify copy screen
+    $bindsym Shift+e exec $grimshot --notify save screen
 
-    bindsym w exec $grimshot --notify copy window
-    bindsym Shift+w exec $grimshot --notify save window
+    $bindsym w exec $grimshot --notify copy window
+    $bindsym Shift+w exec $grimshot --notify save window
 
     # output = currently active output
-    bindsym s exec $grimshot --notify copy output
-    bindsym Shift+s exec $grimshot --notify save output
+    $bindsym s exec $grimshot --notify copy output
+    $bindsym Shift+s exec $grimshot --notify save output
     
     # User can pick the area to screenshot
-    bindsym a exec $grimshot --notify copy area
-    bindsym Shift+a exec $grimshot --notify save area
+    $bindsym a exec $grimshot --notify copy area
+    $bindsym Shift+a exec $grimshot --notify save area
 
     # Return to default mode.
-    bindsym Escape mode "default"
-    bindsym Return mode "default"
+    $bindsym Escape mode "default"
+    $bindsym Return mode "default"
 }
 
 ## Launch // Screenshot Mode ##
-bindsym $mod+Shift+s mode $mode_screenshot
+$bindsym $mod+Shift+s mode $mode_screenshot


### PR DESCRIPTION
Resolves [this issue](https://github.com/Manjaro-Sway/manjaro-sway/issues/98). I've found it more elegant to define $bindsym once and use it elsewhere rather than doing %s/bindsym/bindsym --to-code/ everywhere, in case the user decides to have two different binds for different layouts, $bindsym and $unbindsym can be redefined. It should be noted that if this PR will be merged, from now on we will need to use `$bindsym`, not `bindsym` for consistency.