### PR TITLE
fix rofi command line

### DIFF
--- a/community/sway/etc/sway/definitions
+++ b/community/sway/etc/sway/definitions
@@ -31,7 +31,7 @@ set $term_float_portrait footclient -a floating_shell_portrait
 # Your preferred application launcher
 # Note: pass the final command to swaymsg so that the resulting window can be opened
 # on the original workspace that the command was run on.
-set $menu rofi -show combi -combi-modi "drun,run" -terminal $term -ssh-command  "{terminal} {ssh-client} {host} [-p {port}]" -run-shell-command: "{terminal} {cmd}" -show-icons -font "Roboto Nerd Fonts Mono 14" -lines 10 -width 35
+set $menu rofi -show combi -combi-modi "drun,run" -terminal $term -ssh-command  "{terminal} {ssh-client} {host} [-p {port}]" -run-shell-command "{terminal} {cmd}" -show-icons -font "Roboto Nerd Fonts Mono 14" -lines 10 -width 35
 
 ### Lockscreen configuration
 #


### PR DESCRIPTION
In the rofi config file you need the : at the end of -run-shell-command but not when you pass it directly.