### PR TITLE
fix: add escaping for swaylock command

### DIFF
--- a/community/sway/etc/sway/definitions
+++ b/community/sway/etc/sway/definitions
@@ -29,7 +29,7 @@ set $term_float_portrait footclient -a floating_shell_portrait
 set $menu rofi -show combi -combi-modi "drun,run" -terminal $term -ssh-command  "{terminal} {ssh-client} {host} [-p {port}]" -run-shell-command "{terminal} {cmd}" -show-icons -font "$gui-font" -lines 10 -width 35 -color-normal "$background-color, $text-color, $background-color, $accent-color, $text-color" -color-window "$background-color, $selection-color"
 
 ### Lockscreen configuration
-set $locking swaylock --daemonize --color $selection-color --inside-color $selection-color --inside-clear-color $text-color --ring-color $color2 --ring-clear-color $color11 --ring-ver-color $color13 --show-failed-attempts --fade-in 0.2 --grace 2 --effect-vignette 0.5:0.5 --effect-blur 7x5 --ignore-empty-password --screenshots --clock
+set $locking swaylock --daemonize --color "$selection-color" --inside-color "$selection-color" --inside-clear-color "$text-color" --ring-color "$color2" --ring-clear-color "$color11" --ring-ver-color "$color13" --show-failed-attempts --fade-in 0.2 --grace 2 --effect-vignette 0.5:0.5 --effect-blur 7x5 --ignore-empty-password --screenshots --clock
 
 ###Notification daemon configuration
 set $notifications mako --font "$term-font" --text-color "$text-color" --border-color "$accent-color" --background-color "$background-color" --border-size 3 --width 400 --height 200 --padding 20 --margin 20 --default-timeout 15000


### PR DESCRIPTION
Pretty straightforward: in the dynamic theming commit I forgot to escape colors, thanks @Mathew-D for testing and pointing it out.