### PR TITLE
Flags for native Electron apps

### DIFF
--- a/community/sway/etc/skel/.config/Code - OSS/User/settings.json
+++ b/community/sway/etc/skel/.config/Code - OSS/User/settings.json
@@ -1,4 +1,4 @@
 {
-  "editor.fontFamily": "'Droid Sans Mono', 'RobotoMono Nerd Font', monospace, 'Droid Sans Fallback'",
-  "terminal.integrated.fontFamily": "'RobotoMono Nerd Font', 'Noto Color Emoji', 'Material Design Icons', monospace"
+  "editor.fontFamily": "'RobotoMono Nerd Font', 'Droid Sans Mono',  monospace, 'Droid Sans Fallback'",
+  "terminal.integrated.fontFamily": "'RobotoMono Nerd Font', monospace"
 }

--- a/community/sway/etc/skel/.config/Code/settings.json
+++ b/community/sway/etc/skel/.config/Code/settings.json
@@ -1,4 +1,4 @@
 {
-  "editor.fontFamily": "'Droid Sans Mono', 'RobotoMono Nerd Font', monospace, 'Droid Sans Fallback'",
-  "terminal.integrated.fontFamily": "'RobotoMono Nerd Font', 'Noto Color Emoji', 'Material Design Icons', monospace"
+  "editor.fontFamily": "'RobotoMono Nerd Font', 'Droid Sans Mono',  monospace, 'Droid Sans Fallback'",
+  "terminal.integrated.fontFamily": "'RobotoMono Nerd Font', monospace",
 }

--- a/community/sway/etc/skel/.config/electron-flags.conf
+++ b/community/sway/etc/skel/.config/electron-flags.conf
@@ -1,0 +1,2 @@
+--enable-features=UseOzonePlatform
+--ozone-platform=wayland

--- a/community/sway/etc/skel/.config/electron12-flags.conf
+++ b/community/sway/etc/skel/.config/electron12-flags.conf
@@ -1,0 +1,1 @@
+electron-flags.conf


### PR DESCRIPTION
Makes Electron apps (such as Spotify or Visual Studio Code) work without XWayland
As an additional fix I've changed the terminal font configuration in VSCode to use Nerd Fonts glyphs when possible.