### PR TITLE
fix: disable fullscreen flashing

### DIFF
--- a/community/sway/etc/skel/.config/flashfocus/flashfocus.yml
+++ b/community/sway/etc/skel/.config/flashfocus/flashfocus.yml
@@ -22,7 +22,7 @@ ntimepoints: 20
 flash-on-focus: true
 
 # Set this to false if you don't want fullscreen windows to flash.
-flash-fullscreen: true
+flash-fullscreen: false
 
 # Whether or not to flash windows if they are the only window on the desktop.
 # Possible values:


### PR DESCRIPTION
fullscreen flashing is not working in sway anyway and having this
enabled produces an error message
