### PR TITLE
feat: reduce information display in waybar

### DIFF
--- a/community/sway/etc/skel/.config/waybar/config
+++ b/community/sway/etc/skel/.config/waybar/config
@@ -27,20 +27,19 @@
         "sway/window"
     ],
     "modules-right": [
+        "custom/help",
         "network",
         "bluetooth",
         "cpu",
         "memory",
         "battery",
         "temperature",
-        "backlight",
         "idle_inhibitor",
         "custom/sunset",
         "pulseaudio",
         "custom/pacman",
-        "tray",
         "sway/language",
-        "custom/help",
+        "tray",
         "clock",
     ],
 
@@ -54,17 +53,10 @@
             "warning": 30,
             "critical": 15
         },
-        "format-charging": "󰂄{capacity}%", // Icon: bolt
-        "format": "{icon}{capacity}%",
-        "format-icons": [
-            "󰂃",
-	        "󰁺", // Icon: battery-empty
-            "󰁻", // Icon: battery-quarter
-            "󰁽", // Icon: battery-half
-            "󰂀", // Icon: battery-three-quarters
-            "󰁹"  // Icon: battery-full
-        ],
-        "tooltip": false,
+        "format-charging": "",
+        "format": "{icon}",
+        "format-icons": ["","","","","",""],
+        "tooltip": true,
         "bat": "BAT0"
     },
 
@@ -78,7 +70,7 @@
 
     "cpu": {
         "interval": 5,
-        "format": "󰘚{usage}%", // Icon: microchip
+        "format": "﬙",
         "states": {
             "warning": 70,
             "critical": 90
@@ -88,7 +80,7 @@
 
     "memory": {
         "interval": 5,
-        "format": "󰍛{}%", // Icon: memory
+        "format": "",
         "states": {
             "warning": 70,
             "critical": 90
@@ -98,10 +90,10 @@
 
     "network": {
         "interval": 5,
-        "format-wifi": "󰖩 {essid} ({signalStrength}%)", // Icon: wifi
-        "format-ethernet": "󰈀 {ifname}", // Icon: ethernet
-        "format-disconnected": "󱘖",
-        "tooltip-format": "{ifname}: {ipaddr}",
+        "format-wifi": " ",
+        "format-ethernet": "",
+        "format-disconnected": "睊",
+        "tooltip-format": "{ifname} ({essid}): {ipaddr}",
         "on-click": "swaymsg exec \\$term_float nmtui"
     },
 
@@ -112,50 +104,41 @@
 
     "sway/window": {
         "format": "{}",
-        "max-length": 120
-    },
-
-    "backlight": {
-        "format": "{icon} {percent}%",
-        "format-icons": ["󰃞", "󰃟", "󰃠"],
-        "on-scroll-down": "light -A 1",
-        "on-scroll-up": "light -U 1"
+        "max-length": 80
     },
 
     "idle_inhibitor": {
         "format": "{icon}",
         "format-icons": {
-            "activated": "󰒳",
-            "deactivated": "󰒲"
+            "activated": "零",
+            "deactivated": "鈴"
         }
     },
 
     "pulseaudio": {
-        //"scroll-step": 1,
-        "format": "{icon}{volume}%  󰍬{format_source}",
-        "format-bluetooth": "{icon}󰂰 {volume}%  󰍬{format_source}",
-        "format-muted": "󰖁",
+        "scroll-step": 5,
+        "format": "{icon} {volume}% {format_source}",
+        "format-muted": "婢 {format_source}",
+        "format-source": "{volume}%",
+        "format-source-muted": "",
         "format-icons": {
-            "headphones": "󰋋",
-            "handsfree": "󱋿",
-            "headset": "󰋎",
-            "phone": "󰏲",
-            "portable": "󰄝",
-            "car": "󰄋",
-            "default": ["󰕿", "󰖀", "󰕾"]
+            "headphones": "",
+            "handsfree": "",
+            "headset": "",
+            "phone": "",
+            "portable": "",
+            "car": "",
+            "default": ["奄", "奔", "墳"]
         },
+        "tooltip-format": "{icon} {volume}% {format_source}",
         "on-click": "swaymsg exec \\$pulseaudio"
     },
 
     "temperature": {
       "critical-threshold": 90,
       "interval": 5,
-      "format": "{icon}{temperatureC}°C",
-      "format-icons": [
-          "󱃃",
-          "󰔏", // Icon: temperature ok
-	      "󰔐"  // Icon: temperature not ok
-      ],
+      "format": "{icon}",
+      "format-icons": ["","",""],
       "tooltip": true,
       "on-click": "swaymsg exec \"\\$term_float watch sensors\""
     },
@@ -166,7 +149,7 @@
     },
 
     "custom/pacman": {
-        "format": "󰀼 {}",
+        "format": " {}",
         "interval": 3600,
         "exec-if": "[ $(pamac checkupdates -q | wc -l) -gt 0 ]",
         "exec": "pamac checkupdates -q | wc -l",
@@ -174,13 +157,13 @@
     },
 
     "custom/menu": {
-        "format": "󱘊",
+        "format": "",
         "on-click": "swaymsg exec \\$menu",
         "tooltip": false
     },
 
     "custom/help": {
-        "format": "󰑪",
+        "format": "",
         "on-click": "swaymsg exec \\$help",
         "tooltip": false
     },
@@ -189,19 +172,20 @@
         "format": "{icon}",
         "interval": 30,
         "format-icons": {
-            "enabled": "󰂯",
-            "disabled": "󰂲"
+            "enabled": "",
+            "disabled": ""
         },
         "on-click": "blueberry",
         "tooltip-format": "{}"
     },
+
     "custom/scratchpad": {
         "interval": 1,
         "return-type": "json",
         "format" : "{icon}",
         "format-icons": {
-            "one": "󰀿",
-            "many": "󰪴"
+            "one": "类",
+            "many": "缾"
         },
         "exec": "/bin/sh /usr/share/sway/scripts/scratchpad.sh",
         "on-click": "swaymsg 'scratchpad show'"

--- a/community/sway/etc/skel/.config/waybar/style.css
+++ b/community/sway/etc/skel/.config/waybar/style.css
@@ -73,10 +73,11 @@
 #temperature,
 #idle_inhibitor,
 #backlight,
+#language,
 #custom-sunset,
 #tray {
-    padding-left: 10px;
-    padding-right: 10px;
+    padding-left: 7px;
+    padding-right: 7px;
 }
 
 

--- a/community/sway/etc/sway/modes/default
+++ b/community/sway/etc/sway/modes/default
@@ -33,6 +33,9 @@ $bindsym XF86AudioLowerVolume exec $onscreen_bar $(amixer sset Master 5%- | sed 
 ## Action // Mute volume of Master ##
 $bindsym XF86AudioMute exec $onscreen_bar $(amixer sset Master toggle | sed -En '/\[on\]/ s/.*\[([0-9]+)%\].*/\1/ p; /\[off\]/ s/.*/0/p' | head -1)
 
+## Action // Mute volume of Master Input ##
+$bindsym XF86AudioMicMute exec $onscreen_bar $(amixer set Capture toggle | sed -En '/\[on\]/ s/.*\[([0-9]+)%\].*/\1/ p; /\[off\]/ s/.*/0/p' | head -1)
+
 ## Action // Increase brightness ##
 $bindsym XF86MonBrightnessUp exec light -A 5 && $onscreen_bar $(light -G | cut -d'.' -f1)
 

--- a/community/sway/etc/sway/modes/resize
+++ b/community/sway/etc/sway/modes/resize
@@ -1,4 +1,4 @@
-set $mode_resize "<span foreground='$color10'>󰁌</span>  \
+set $mode_resize "<span foreground='$color10'></span>  \
 <span foreground='$color5'><b>Resize</b></span> <span foreground='$color10'>(<b>h/j/k/l</b>)</span> \
 <span foreground='$color1'>—</span> \
 <span foreground='$color5'><b>Increase Gaps</b></span> <span foreground='$color10'>(<b>+</b>)</span> \

--- a/community/sway/usr/share/sway/scripts/sunset.sh
+++ b/community/sway/usr/share/sway/scripts/sunset.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #Startup function
 function start(){
@@ -15,8 +15,10 @@ function start(){
 	if [ "${location}" = "on" ]; 
 	then
 		CONTENT=$(curl -s https://freegeoip.app/json/)
-		longitude=${$(echo $CONTENT | jq '.longitude // empty'):-"${longitude}"}
-		latitude=${$(echo $CONTENT | jq '.latitude // empty'):-"${latitude}"}
+		content_longitude=$(echo $CONTENT | jq '.longitude // empty')
+        longitude=${content_longitude:-"${longitude}"}
+        content_latitude=$(echo $CONTENT | jq '.latitude // empty')
+        latitude=${content_latitude:-"${latitude}"}
 		wlsunset -l $latitude -L $longitude -t $temp_low -T $temp_high -d $duration &
 	else
 		wlsunset -t $temp_low -T $temp_high -d $duration -S $sunrise -s $sunset &


### PR DESCRIPTION
I'd like to propose that we get rid of most of the 'verbose' information in waybar. Most of it is available through tooltips anyway and otherwise just limits the available space f.e. for the window titles even on higher res displays. 

In addition moving to nerd-font,
closes https://github.com/Manjaro-Sway/manjaro-sway/issues/109