### PR TITLE
Add smart_gaps on to the config

### DIFF
--- a/community/sway/etc/sway/config.d/98-application-defaults.conf
+++ b/community/sway/etc/sway/config.d/98-application-defaults.conf
@@ -1,3 +1,6 @@
+#don't show gaps if there's only one window on the desktop
+smart_gaps on
+
 # set floating mode for specific applications
 for_window [instance="lxappearance"] floating enable
 for_window [app_id="pamac-manager"] floating enable


### PR DESCRIPTION
That's a pretty simple trick that allows the firefox window, for example, to be nearly fullscreen when it's the only window on the desktop.