### PR TITLE
Fix Zsh startup time

### DIFF
--- a/community/sway/etc/skel/.config/zsh/.zshrc
+++ b/community/sway/etc/skel/.config/zsh/.zshrc
@@ -1,14 +1,6 @@
 # base config for oh my zsh
 source /usr/share/oh-my-zsh/zshrc
 
-# oh my zsh overrides
-plugins=(
-    archlinux
-    git
-)
-
-ZSH_THEME="agnoster"
-
 [ -d ~/.config/zsh/config.d/ ] && source ~/.config/zsh/config.d/*
 
 # Source manjaro config

--- a/community/sway/etc/skel/.config/zsh/.zshrc
+++ b/community/sway/etc/skel/.config/zsh/.zshrc
@@ -11,8 +11,6 @@ ZSH_THEME="agnoster"
 
 [ -d ~/.config/zsh/config.d/ ] && source ~/.config/zsh/config.d/*
 
-source $ZSH/oh-my-zsh.sh
-
 # Source manjaro config
 source ~/.zshrc
 

--- a/community/sway/etc/skel/.config/zsh/.zshrc
+++ b/community/sway/etc/skel/.config/zsh/.zshrc
@@ -1,6 +1,11 @@
 # base config for oh my zsh
 source /usr/share/oh-my-zsh/zshrc
 
+#p10k instant prompt to make terminal open a bit snappier
+if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]; then
+  source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
+fi
+
 # Source manjaro config
 source ~/.zshrc
 

--- a/community/sway/etc/skel/.config/zsh/.zshrc
+++ b/community/sway/etc/skel/.config/zsh/.zshrc
@@ -1,9 +1,11 @@
 # base config for oh my zsh
 source /usr/share/oh-my-zsh/zshrc
 
-[ -d ~/.config/zsh/config.d/ ] && source ~/.config/zsh/config.d/*
-
 # Source manjaro config
 source ~/.zshrc
 
+# user-defined overrides
+[ -d ~/.config/zsh/config.d/ ] && source ~/.config/zsh/config.d/*
+
+# Fix for foot terminfo not installed on most servers
 alias ssh="TERM=xterm-256color ssh"


### PR DESCRIPTION
I was very upset with the default config of zsh because of how slow it loaded. It took up to a second to launch a terminal, which is a really unremarkable result. Even after removing double imports for the Manjaro themes, a problem persisted. I am rocking my own zsh config without using OMZ, but still I decided to look inside, because it can't be THAT slow. (The command used for benchmark is `for i in $(seq 1 10); do time $SHELL -i -c exit; done`
```$SHELL -i -c exit  0,49s user 0,16s system 100% cpu 0,646 total
$SHELL -i -c exit  0,48s user 0,14s system 100% cpu 0,615 total
$SHELL -i -c exit  0,48s user 0,13s system 100% cpu 0,604 total
$SHELL -i -c exit  0,49s user 0,11s system 100% cpu 0,594 total
$SHELL -i -c exit  0,49s user 0,11s system 100% cpu 0,592 total
$SHELL -i -c exit  0,45s user 0,15s system 100% cpu 0,592 total
$SHELL -i -c exit  0,51s user 0,09s system 100% cpu 0,592 total
$SHELL -i -c exit  0,48s user 0,12s system 100% cpu 0,589 total
$SHELL -i -c exit  0,48s user 0,12s system 100% cpu 0,591 total
$SHELL -i -c exit  0,47s user 0,13s system 100% cpu 0,594 total
```

Sure enough, there was a problem: double import of OMZ made a very big regression, fixing that made the shell **start 5 times faster.** With some further tweaking such as utilizing amazing powerlevel10k feature called "Instant Prompt" (which is not perceived by benchmarks but rather visually), my current result is:
```
$SHELL -i -c exit  0,09s user 0,04s system 100% cpu 0,129 total
$SHELL -i -c exit  0,09s user 0,03s system 101% cpu 0,118 total
$SHELL -i -c exit  0,09s user 0,03s system 101% cpu 0,118 total
$SHELL -i -c exit  0,09s user 0,03s system 101% cpu 0,119 total
$SHELL -i -c exit  0,10s user 0,02s system 101% cpu 0,118 total
$SHELL -i -c exit  0,10s user 0,02s system 101% cpu 0,120 total
$SHELL -i -c exit  0,09s user 0,03s system 101% cpu 0,118 total
$SHELL -i -c exit  0,09s user 0,03s system 101% cpu 0,112 total
$SHELL -i -c exit  0,09s user 0,02s system 101% cpu 0,111 total
$SHELL -i -c exit  0,08s user 0,03s system 100% cpu 0,111 total
```