### PR TITLE
add parameter "min-length" for "sway/language"

### DIFF
--- a/community/sway/etc/skel/.config/waybar/config
+++ b/community/sway/etc/skel/.config/waybar/config
@@ -181,7 +181,12 @@
         "on-click": "blueberry",
         "tooltip-format": "{}"
     },
-
+    
+    "sway/language": {
+        "format": " {}",
+        "min-length": 5,
+    },
+    
     "custom/scratchpad": {
         "interval": "once",
         "return-type": "json",


### PR DESCRIPTION
I noticed that the "Sway / Language" module behaves strange.
After several iterations for changing the layout of the keyboard and applications, it begins to show instead of the language "...".
I found out that the problem with the allocated spaces, for the module on the panel.
The problem was solved by adding "min-length".
Also, I added an icon for this module to follow the overall style of design. 