### PR TITLE
Fix error when starting playerctl 

### DIFF
--- a/community/sway/etc/skel/.config/waybar/config
+++ b/community/sway/etc/skel/.config/waybar/config
@@ -181,7 +181,12 @@
         "on-click": "blueberry",
         "tooltip-format": "{}"
     },
-
+    
+    "sway/language": {
+        "format": " {}",
+        "min-length": 5,
+    },
+    
     "custom/scratchpad": {
         "interval": "once",
         "return-type": "json",

--- a/community/sway/etc/sway/config.d/99-autostart-applications.conf
+++ b/community/sway/etc/sway/config.d/99-autostart-applications.conf
@@ -19,5 +19,5 @@ exec_always {
     # restart kanshi https://github.com/emersion/kanshi/issues/43#issuecomment-531679213
     '[ -x "$(command -v kanshi)" ] && pkill kanshi; exec kanshi'
     '[ -x "$(command -v sworkstyle)" ] && pkill sworkstyle; sworkstyle &> /tmp/sworkstyle.log'
-    '[ -x "$(command -v playerctl)" ] && pkill playerctl; playerctl -a metadata --format '{{status}} {{title}}' --follow | while read line; do pkill -RTMIN+5 waybar; done'
+    '[ -x "$(command -v playerctl)" ] && pkill playerctl; playerctl -a metadata --format \'{{status}} {{title}}\' --follow | while read line; do pkill -RTMIN+5 waybar; done'
 }


### PR DESCRIPTION
I checked this fragment. I found that `playerctl` does not start.
The problem is caused by uninsulated quotes, because At the beginning and end of the line there are quotes of the same kind 