### PR TITLE
fix: Call vim cmd correctly from init.lua

### DIFF
--- a/community/sway/etc/skel/.config/nvim/init.lua
+++ b/community/sway/etc/skel/.config/nvim/init.lua
@@ -1,2 +1,2 @@
 -- By default title is off. Needed for detecting window as neovim instance (sworkstyle)
-cmd "set title"
+vim.cmd "set title"


### PR DESCRIPTION
The previous config threw an error at neovim startup, now it works properly and the icon is shown in the bar.