### PR TITLE
feat: unify up-left-down-right navigation

### DIFF
--- a/community/sway/etc/sway/definitions
+++ b/community/sway/etc/sway/definitions
@@ -3,19 +3,17 @@
 # Logo key. Use Mod1 for Alt and Mod4 for Super.
 set $mod Mod4
 
-# Home row direction keys, like vim
-set $left h
-set $down j
-set $up k
-set $right l
-
+# Direction keys
+set $left Left
+set $down Down
+set $up Up
+set $right Right
 
 # Add --to-code to bindsym, support for non-latin layouts
 set $bindsym bindsym --to-code
 
 # For user's convenience, the same for unbindsym
 set $unbindsym unbindsym --to-code
-
 
 # background
 set $background /usr/share/backgrounds/manjaro-sway/gruvbox-dark-manjarosway-3840x2160.png
@@ -39,7 +37,6 @@ set $locking swaylock --daemonize --color "$selection-color" --inside-color "$se
 
 ###Notification daemon configuration
 set $notifications mako --font "$term-font" --text-color "$text-color" --border-color "$accent-color" --background-color "$background-color" --border-size 3 --width 400 --height 200 --padding 20 --margin 20 --default-timeout 15000
-
 
 ### Idle configuration
 # This will lock your screen after 300 seconds of inactivity, then turn off

--- a/community/sway/etc/sway/modes/default
+++ b/community/sway/etc/sway/modes/default
@@ -53,16 +53,16 @@ $bindsym XF86TouchpadToggle input type:touchpad events toggle enabled disabled
 #
 # Move your focus around
 ## Navigation // Move focus // $mod + ↑ ↓ ← → ##
-$bindsym $mod+Left focus left
-$bindsym $mod+Down focus down
-$bindsym $mod+Up focus up
-$bindsym $mod+Right focus right
+$bindsym $mod+$left focus left
+$bindsym $mod+$down focus down
+$bindsym $mod+$up focus up
+$bindsym $mod+$right focus right
 
 ## Navigation // Move focused window // $mod + Shift + ↑ ↓ ← → ##
-$bindsym $mod+Shift+Left move left
-$bindsym $mod+Shift+Down move down
-$bindsym $mod+Shift+Up move up
-$bindsym $mod+Shift+Right move right
+$bindsym $mod+Shift+$left move left
+$bindsym $mod+Shift+$down move down
+$bindsym $mod+Shift+$up move up
+$bindsym $mod+Shift+$right move right
 
 #
 # Workspaces:

--- a/community/sway/etc/sway/modes/resize
+++ b/community/sway/etc/sway/modes/resize
@@ -1,5 +1,5 @@
 set $mode_resize "<span foreground='$color10'></span>  \
-<span foreground='$color5'><b>Resize</b></span> <span foreground='$color10'>(<b>h/j/k/l</b>)</span> \
+<span foreground='$color5'><b>Resize</b></span> <span foreground='$color10'>(<b>↑ ↓ ← →</b>)</span> \
 <span foreground='$color5'><b>Increase Gaps</b></span> <span foreground='$color10'>(<b>+</b>)</span> \
 <span foreground='$color5'><b>Decrease Gaps</b></span> <span foreground='$color10'>(<b>-</b>)</span>"
 
@@ -16,16 +16,6 @@ mode --pango_markup $mode_resize {
     $bindsym Shift+$down resize grow height 20px
     $bindsym Shift+$up resize shrink height 20px
     $bindsym Shift+$right resize grow width 20px
-
-    # Ditto, with arrow keys
-    $bindsym Left resize shrink width 10px
-    $bindsym Down resize grow height 10px
-    $bindsym Up resize shrink height 10px
-    $bindsym Right resize grow width 10px
-    $bindsym Shift+Left resize shrink width 20px
-    $bindsym Shift+Down resize grow height 20px
-    $bindsym Shift+Up resize shrink height 20px
-    $bindsym Shift+Right resize grow width 20px
 
     ## Resize // Window Gaps // + - ##
     $bindsym minus gaps inner current minus 5px


### PR DESCRIPTION
the $left $down $up $right variables were only used inside the resize menu, not for navigation. that confused people multiple times (https://github.com/Manjaro-Sway/manjaro-sway/issues/167, https://github.com/Manjaro-Sway/manjaro-sway/issues/145).

The assumption of this PR is, that users want to use h/j/k/l OR w/a/s/d OR the arrow keys as directional keys globally, defaulting to the arrow keys, to not break it for current users too much.

closes https://github.com/Manjaro-Sway/manjaro-sway/issues/167