### PR TITLE
feat: add upload mode to screenshots

### DIFF
--- a/community/sway/etc/sway/definitions
+++ b/community/sway/etc/sway/definitions
@@ -84,7 +84,10 @@ set $ws10 number 10
 
 # screenshot 
 set $grimshot /usr/share/sway/scripts/grimshot
+set $image_upload /usr/share/sway/scripts/upload-image.sh
 set $screenshot_screen_clipboard $grimshot --notify copy output
 set $screenshot_screen_file $grimshot --notify save output
+set $screenshot_screen_upload $grimshot --notify save output | xargs $image_upload
 set $screenshot_selection_clipboard $grimshot --notify copy window
 set $screenshot_selection_file $grimshot --notify save window
+set $screenshot_selection_upload $grimshot --notify save window | xargs $image_upload

--- a/community/sway/etc/sway/definitions
+++ b/community/sway/etc/sway/definitions
@@ -87,7 +87,7 @@ set $grimshot /usr/share/sway/scripts/grimshot
 set $image_upload /usr/share/sway/scripts/upload-image.sh
 set $screenshot_screen_clipboard $grimshot --notify copy output
 set $screenshot_screen_file $grimshot --notify save output
-set $screenshot_screen_upload $grimshot --notify save output | xargs $image_upload
+set $screenshot_screen_upload $screenshot_screen_file | xargs $image_upload
 set $screenshot_selection_clipboard $grimshot --notify copy window
 set $screenshot_selection_file $grimshot --notify save window
-set $screenshot_selection_upload $grimshot --notify save window | xargs $image_upload
+set $screenshot_selection_upload $screenshot_selection_file | xargs $image_upload

--- a/community/sway/etc/sway/modes/screenshot
+++ b/community/sway/etc/sway/modes/screenshot
@@ -1,16 +1,19 @@
 set $mode_screenshot "<span foreground='$color10'></span>  \
 <span foreground='$color5'><b>Pick</b></span> <span foreground='$color10'>(<b>p</b>)</span> \
 <span foreground='$color5'><b>Output</b></span> <span foreground='$color10'>(<b>o</b>)</span> \
-<span foreground='$color7'>+ [<span foreground='$color10'><b>Shift</b></span> for ]</span>"
+<span foreground='$color7'>+ <span foreground='$color10'><b>Shift</b></span> for </span> \
+<span foreground='$color7'>+ <span foreground='$color10'><b>Ctrl</b></span> for </span>"
 
 mode --pango_markup $mode_screenshot {
     # output = currently active output
     $bindsym o mode "default", exec $screenshot_screen_clipboard
     $bindsym Shift+o mode "default", exec $screenshot_screen_file
+    $bindsym Shift+Ctrl+o mode "default", exec $screenshot_screen_upload
 
     # pick the region to screenshot
     $bindsym p mode "default", exec $screenshot_selection_clipboard
     $bindsym Shift+p mode "default", exec $screenshot_selection_file
+    $bindsym Shift+Ctrl+p mode "default", exec $screenshot_selection_upload
 
     # Return to default mode.
     $bindsym Escape mode "default"

--- a/community/sway/usr/share/sway/scripts/upload-image.sh
+++ b/community/sway/usr/share/sway/scripts/upload-image.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+URL=$(curl -s -F "file=@\"$1\";filename=.png" 'https://x0.at')
+echo $URL | wl-copy
+notify-send " $URL"


### PR DESCRIPTION
closes https://github.com/Manjaro-Sway/manjaro-sway/issues/162

by providing a tiny upload script alongside our existing screenshot tool. I decided not to go with swayshot because I didn't understand / get to use its clipboard behavior and I think our current mode has undergone long and careful optimization. The addition basically means that if you press shift+ctrl+p/o it will save & upload.