### PR TITLE
fix: make only firefox library window floating

### DIFF
--- a/community/sway/etc/sway/config.d/98-application-defaults.conf
+++ b/community/sway/etc/sway/config.d/98-application-defaults.conf
@@ -5,7 +5,7 @@ smart_gaps on
 for_window [instance="lxappearance"] floating enable
 for_window [app_id="pamac-manager"] floating enable
 for_window [app_id="blueberry.py"] floating enable
-for_window [app_id="firefox" title="Library"] floating enable, border pixel 1, sticky enable
+for_window [app_id="firefox" title="^Library$"] floating enable, border pixel 1, sticky enable
 for_window [app_id="thunderbird" title=".*Reminder"] floating enable
 for_window [app_id="floating_shell_portrait"] floating enable, border pixel 1, sticky enable, resize set width 30 ppt height 40 ppt
 for_window [app_id="floating_shell"] floating enable, border pixel 1, sticky enable


### PR DESCRIPTION
Firefox window went into floating mode whenever "Library" was in the title -- try https://en.wikipedia.org/wiki/Library, for example. This commit fixes that.