### PR TITLE
fix: wlay regex for floating mode rule

### DIFF
--- a/community/sway/etc/sway/config.d/98-application-defaults.conf
+++ b/community/sway/etc/sway/config.d/98-application-defaults.conf
@@ -15,7 +15,7 @@ for_window [app_id="xsensors"] floating enable
 for_window [title="Save File"] floating enable
 for_window [title="Firefox — Sharing Indicator"] floating enable
 for_window [app_id="" title=".* is sharing your screen."] floating enable
-for_window [title="wlay"] floating enable
+for_window [title="^wlay$"] floating enable
 
 # inhibit idle
 for_window [app_id="microsoft teams - preview"] inhibit_idle fullscreen


### PR DESCRIPTION
Other windows than wlay, such as firefox, went into floating mode when "wlay" was in the window title (try https://github.com/Manjaro-Sway/wlay, for example). The wlay window does not have an `app_id`.