### PR TITLE
fix: update foot.ini to continue using foot-terminfo

### DIFF
--- a/community/sway/usr/share/sway/templates/foot.ini
+++ b/community/sway/usr/share/sway/templates/foot.ini
@@ -1,7 +1,7 @@
 # -*- conf -*-
 
 # shell=$SHELL (if set, otherwise user's default shell from /etc/passwd)
-# term=foot (or xterm-256color if built with -Dterminfo=disabled)
+term=foot-extra #(or xterm-256color if built with -Dterminfo=disabled)
 # login-shell=no
 
 font=RobotoMono Nerd Font Mono:size=8


### PR DESCRIPTION
Allows using terminfo provided by foot-terminfo after update to 1.10.0-1.