### PR TITLE
Variable names in quotes

### DIFF
--- a/community/sway/etc/sway/config.d/90-enable-gtk-theme.conf
+++ b/community/sway/etc/sway/config.d/90-enable-gtk-theme.conf
@@ -1,6 +1,6 @@
 exec_always {
-  gsettings set org.gnome.desktop.interface gtk-theme $gtk-theme
-  gsettings set org.gnome.desktop.interface icon-theme $icon-theme
-  gsettings set org.gnome.desktop.interface cursor-theme $cursor-theme
-  gsettings set org.gnome.desktop.interface font-name $gui-font
+  gsettings set org.gnome.desktop.interface gtk-theme "$gtk-theme"
+  gsettings set org.gnome.desktop.interface icon-theme "$icon-theme"
+  gsettings set org.gnome.desktop.interface cursor-theme "$cursor-theme"
+  gsettings set org.gnome.desktop.interface font-name "$gui-font"
 }


### PR DESCRIPTION
For specifications with spaces in the name, the variables should probably be in quotes.