### PR TITLE
fix: increment brightness on raw hardware scale

### DIFF
--- a/community/sway/etc/sway/modes/default
+++ b/community/sway/etc/sway/modes/default
@@ -32,9 +32,9 @@ $bindsym XF86AudioMute exec $onscreen_bar $(pactl set-sink-mute @DEFAULT_SINK@ t
 
 $bindsym XF86AudioMicMute exec $onscreen_bar $(pactl set-source-mute @DEFAULT_SOURCE@ toggle && pactl get-source-mute @DEFAULT_SOURCE@ | sed -En "/no/ s/.*/$($source_volume)/p; /yes/ s/.*/0/p")
 
-$bindsym XF86MonBrightnessUp exec light -T 1.05 && $onscreen_bar $(light -G | cut -d'.' -f1)
+$bindsym XF86MonBrightnessUp exec light -r -A 1 && $onscreen_bar $(light -G | cut -d'.' -f1)
 
-$bindsym XF86MonBrightnessDown exec light -T 0.95 && $onscreen_bar $(light -G | cut -d'.' -f1)
+$bindsym XF86MonBrightnessDown exec light -r -U 1 && $onscreen_bar $(light -G | cut -d'.' -f1)
 
 $bindsym XF86AudioPlay exec playerctl play-pause
 

--- a/community/sway/etc/sway/modes/default
+++ b/community/sway/etc/sway/modes/default
@@ -32,9 +32,9 @@ $bindsym XF86AudioMute exec $onscreen_bar $(pactl set-sink-mute @DEFAULT_SINK@ t
 
 $bindsym XF86AudioMicMute exec $onscreen_bar $(pactl set-source-mute @DEFAULT_SOURCE@ toggle && pactl get-source-mute @DEFAULT_SOURCE@ | sed -En "/no/ s/.*/$($source_volume)/p; /yes/ s/.*/0/p")
 
-$bindsym XF86MonBrightnessUp exec light -A 5 && $onscreen_bar $(light -G | cut -d'.' -f1)
+$bindsym XF86MonBrightnessUp exec light -T 1.05 && $onscreen_bar $(light -G | cut -d'.' -f1)
 
-$bindsym XF86MonBrightnessDown exec light -U 5 && $onscreen_bar $(light -G | cut -d'.' -f1)
+$bindsym XF86MonBrightnessDown exec light -T 0.95 && $onscreen_bar $(light -G | cut -d'.' -f1)
 
 $bindsym XF86AudioPlay exec playerctl play-pause
 

--- a/community/sway/usr/share/sway/templates/waybar/config.jsonc
+++ b/community/sway/usr/share/sway/templates/waybar/config.jsonc
@@ -116,8 +116,8 @@
     "backlight": {
         "format": "{icon} {percent}%",
         "format-icons": ["", "", ""],
-        "on-scroll-up": "light -T 1.05",
-        "on-scroll-down": "light -T 0.95"
+        "on-scroll-up": "light -r -A 1",
+        "on-scroll-down": "light -r -U 1"
     },
 
     "pulseaudio": {

--- a/community/sway/usr/share/sway/templates/waybar/config.jsonc
+++ b/community/sway/usr/share/sway/templates/waybar/config.jsonc
@@ -116,8 +116,8 @@
     "backlight": {
         "format": "{icon} {percent}%",
         "format-icons": ["", "", ""],
-        "on-scroll-up": "light -A 1",
-        "on-scroll-down": "light -U 1"
+        "on-scroll-up": "light -T 1.05",
+        "on-scroll-down": "light -T 0.95"
     },
 
     "pulseaudio": {


### PR DESCRIPTION
for many devices, the brightness scale ranges from 1 to 15. On those displays a fraction equals 100/15=6.6666_.
When we tried to increment using a fraction of the absolute (e.g 5% of 15), we tried to actually increment it with a value lower than 1. We could now set it to something higher, like 6.7%, but why not use the best precision for each device.