### PR TITLE
fix: show "Pause" icon on waybar when sth's playing

### DIFF
--- a/community/sway/usr/share/sway/templates/waybar/config.jsonc
+++ b/community/sway/usr/share/sway/templates/waybar/config.jsonc
@@ -240,8 +240,8 @@
         "return-type": "json",
         "format": "{icon}",
         "format-icons": {
-            "Playing": "奈",
-            "Paused": ""
+            "Playing": "",
+            "Paused": "奈"
         },
         "exec": "playerctl metadata --format '{\"alt\": \"{{status}}\", \"tooltip\": \"{{playerName}}:  {{markup_escape(title)}} - {{markup_escape(artist)}}\" }'",
         "on-click": "playerctl play-pause; pkill -RTMIN+5 waybar",


### PR DESCRIPTION
I found it weird to pause the player by pressing the "Play" icon and vice versa. I think this is more intuitive. Please ignore if irrelevant