### PR TITLE
fix: use quotes

### DIFF
--- a/community/sway/usr/share/sway/scripts/foot.sh
+++ b/community/sway/usr/share/sway/scripts/foot.sh
@@ -3,7 +3,7 @@
 
 USER_CONFIG_PATH=${HOME}/.config/foot/foot.ini
 
-if [ -f $USER_CONFIG_PATH ]; then
+if [ -f "$USER_CONFIG_PATH" ]; then
     USER_CONFIG=$USER_CONFIG_PATH
 fi
 


### PR DESCRIPTION
Quotation marks do have a purpose. Try the linter shellcheck. At least take over everything if you get the solution as a gift.