### PR TITLE
fix: reenable floating picture-in-picture for firefox

### DIFF
--- a/community/sway/etc/sway/config.d/98-application-defaults.conf
+++ b/community/sway/etc/sway/config.d/98-application-defaults.conf
@@ -11,6 +11,7 @@ for_window [app_id="floating_shell_portrait"] floating enable, border pixel 1, s
 for_window [app_id="floating_shell"] floating enable, border pixel 1, sticky enable
 for_window [app_id="Manjaro.manjaro-settings-manager"] floating enable
 for_window [app_id="" title="Picture in picture"] floating enable, sticky enable
+for_window [app_id="" title="Picture-in-Picture"] floating enable, sticky enable
 for_window [app_id="xsensors"] floating enable
 for_window [title="Save File"] floating enable
 for_window [title="Firefox — Sharing Indicator"] floating enable


### PR DESCRIPTION
Fix picture in picture floating for mode for Firefox.

Is the title  "Picture in picture" used elsewhere or can it be removed?