### PR TITLE
fix(wlsunset): allow passing longitude and latitude

### DIFF
--- a/community/sway/usr/share/sway/scripts/sunset.sh
+++ b/community/sway/usr/share/sway/scripts/sunset.sh
@@ -1,60 +1,64 @@
 #!/bin/bash
 
-#Startup function
-function start(){
-	[[ -f "$HOME/.config/wlsunset/config" ]] && source "$HOME/.config/wlsunset/config"
-	temp_low=${temp_low:-"4000"}
-	temp_high=${temp_high:-"6500"}
-	duration=${duration:-"900"}
-	sunrise=${sunrise:-"07:00"}
-	sunset=${sunset:-"19:00"}
-	longitude=${longitude:-65}
-	latitude=${latitude:-65}
-	location=${location:-"off"}
-
-	if [ "${location}" = "on" ]; 
-	then
-		CONTENT=$(curl -s https://freegeoip.app/json/)
-		content_longitude=$(echo $CONTENT | jq '.longitude // empty')
-        longitude=${content_longitude:-"${longitude}"}
-        content_latitude=$(echo $CONTENT | jq '.latitude // empty')
-        latitude=${content_latitude:-"${latitude}"}
-		wlsunset -l $latitude -L $longitude -t $temp_low -T $temp_high -d $duration &
-	else
-		wlsunset -t $temp_low -T $temp_high -d $duration -S $sunrise -s $sunset &
-	fi
+function get_geo() {
+    GEO_CONTENT=${GEO_CONTENT:-$(curl -sL https://freegeoip.app/json/)}
+    echo $GEO_CONTENT
 }
 
-#Accepts managing parameter 
+#Startup function
+function start() {
+    [[ -f "$HOME/.config/wlsunset/config" ]] && source "$HOME/.config/wlsunset/config"
+    temp_low=${temp_low:-"4000"}
+    temp_high=${temp_high:-"6500"}
+    duration=${duration:-"900"}
+    sunrise=${sunrise:-"07:00"}
+    sunset=${sunset:-"19:00"}
+    location=${location:-"on"}
+    fallback_longitude=${fallback_longitude:-"8.7"}
+    fallback_latitude=${fallback_latitude:-"50.1"}
+
+    if [ "${location}" = "on" ]; then
+        longitude=${longitude:-$(get_geo | jq '.longitude // empty')}
+        longitude=${longitude:-$fallback_longitude}
+        latitude=${latitude:-$(get_geo | jq '.latitude // empty')}
+        latitude=${latitude:-$fallback_latitude}
+
+        echo longitude: $longitude latitude: $latitude
+
+        wlsunset -l $latitude -L $longitude -t $temp_low -T $temp_high -d $duration &
+    else
+        wlsunset -t $temp_low -T $temp_high -d $duration -S $sunrise -s $sunset &
+    fi
+}
+
+#Accepts managing parameter
 case $1'' in
-	'off')
-   	pkill wlsunset
-	;;
-
-	'on')
-	start
-	;;
-
-	'toggle')
-   	if pkill -0 wlsunset
-	then
-		pkill wlsunset
-	else
-		start
-	fi
+'off')
+    pkill wlsunset
     ;;
-    'check')
+
+'on')
+    start
+    ;;
+
+'toggle')
+    if pkill -0 wlsunset; then
+        pkill wlsunset
+    else
+        start
+    fi
+    ;;
+'check')
     command -v wlsunset
     exit $?
     ;;
 esac
 
-#Returns a string for Waybar 
-if pkill -0 wlsunset
-then
-	class="on"
+#Returns a string for Waybar
+if pkill -0 wlsunset; then
+    class="on"
 else
-	class="off"
-fi	
+    class="off"
+fi
 
 printf '{"alt":"%s"}\n' "$class"

--- a/community/sway/usr/share/sway/templates/waybar/config.jsonc
+++ b/community/sway/usr/share/sway/templates/waybar/config.jsonc
@@ -204,7 +204,7 @@
             "on": "",
             "off": ""
         },
-        "exec": "/usr/share/sway/scripts/sunset.sh",
+        "exec": "fallback_latitude=50.1 fallback_longitude=8.7 latitude= longitude= /usr/share/sway/scripts/sunset.sh",
         "on-click": "/usr/share/sway/scripts/sunset.sh toggle; pkill -RTMIN+6 waybar",
         "exec-if": "/usr/share/sway/scripts/sunset.sh check",
         "signal": 6


### PR DESCRIPTION
closes https://github.com/Manjaro-Sway/manjaro-sway/issues/272

- per default uses geoip
- if geoip not available/returns nothing, it uses a fallback (`fallback_latitude= fallback_longitude=`)
- if `latitude= longitude=` are set, it uses that instead