### PR TITLE
chore: remove unnecessary sworkstyle concurrency check

### DIFF
--- a/community/sway/etc/sway/config.d/99-autostart-applications.conf
+++ b/community/sway/etc/sway/config.d/99-autostart-applications.conf
@@ -16,12 +16,12 @@ exec {
     '[ -x "$(command -v nwg-wrapper)" ] && [ -f $HOME/.config/nwg-wrapper/help.sh ] && /usr/share/sway/scripts/help.sh'
     '[ -x "$(command -v wl-paste)" ] && [ -x "$(command -v cliphist)" ] && wl-paste --watch cliphist store'
     '[ -x "$(command -v wl-paste)" ] && [ -x "$(command -v cliphist)" ] && wl-paste --watch pkill -RTMIN+9 waybar'
+    '[ -x "$(command -v sworkstyle)" ] && RUST_LOG=info sworkstyle &> /tmp/sworkstyle.log'
 }
 exec_always {
     '[ -x "$(command -v spice-vdagent)" ] && spice-vdagent'
     # restart kanshi https://github.com/emersion/kanshi/issues/43#issuecomment-531679213
     '[ -x "$(command -v kanshi)" ] && pkill kanshi; exec kanshi'
-    '[ -x "$(command -v sworkstyle)" ] && pkill sworkstyle; RUST_LOG=info sworkstyle &> /tmp/sworkstyle.log'
     '[ -x "$(command -v playerctl)" ] && pkill playerctl; playerctl -a metadata --format \'{{status}} {{title}}\' --follow | while read line; do pkill -RTMIN+5 waybar; done'
     '[ -x "$(command -v poweralertd)" ] && pkill poweralertd; poweralertd -s -i "line power" &'
 }


### PR DESCRIPTION
Sworkstyle uses a lock file to know if it is already running or not. This already prevents multiple instances of sworkstyle.
I think killing and restarting on each sway update causes this issue https://github.com/Lyr-7D1h/swayest_workstyle/issues/29. 
My proposed changes should fix this.