### PR TITLE
bug fix: remove extra "

### DIFF
--- a/community/sway/usr/share/sway/templates/waybar/config.jsonc
+++ b/community/sway/usr/share/sway/templates/waybar/config.jsonc
@@ -303,7 +303,7 @@
         },
         "exec": "/bin/sh /usr/share/sway/scripts/zeit.sh status",
         "on-click": "/bin/sh /usr/share/sway/scripts/zeit.sh click; pkill -RTMIN+10 waybar",
-        "exec-if": "[ -x \"$(command -v zeit)\" ]",
+        "exec-if": "[ -x $(command -v zeit) ]",
         "signal": 10
     },
 


### PR DESCRIPTION
Hello there 👋🏿 ,

found a small bug. If you remove the " then swaybar shows zeit on the swaybar otherwise gets ignored. 

Here also a small test
![image](https://user-images.githubusercontent.com/7304125/187471967-3359720f-ed99-483a-a593-09975a491fb6.png)

Once again thank you for maintaining manjaro-sway 👏🏿 