### PR TITLE
feat: set eurkey as default keyboard layout

### DIFF
--- a/community/sway/etc/sway/inputs/default-keyboard
+++ b/community/sway/etc/sway/inputs/default-keyboard
@@ -2,4 +2,4 @@
 #
 # You can get the names of your inputs by running: swaymsg -t get_inputs
 # Read `man 5 sway-input` for more information about this section.
-input type:keyboard xkb_layout "us"
+input type:keyboard xkb_layout "eu"


### PR DESCRIPTION
just a proposal, but it would allow most users from us and europe to type out of the box.

ref: https://eurkey.steffen.bruentjen.eu/

Signed-off-by: Jonas Strassel <info@jonas-strassel.de>