### PR TITLE
Declare WLR_NO_HARDWARE_CURSORS env variable

### DIFF
--- a/community/sway/etc/skel/.profile
+++ b/community/sway/etc/skel/.profile
@@ -22,3 +22,7 @@ export TERMINAL_COMMAND=/usr/share/sway/scripts/foot.sh
 
 # add default location for zeit.db
 export ZEIT_DB=~/.config/zeit.db
+
+# Disable hardware cursors. This might fix issues with
+# disappearing cursors
+export WLR_NO_HARDWARE_CURSORS=1


### PR DESCRIPTION
Disabling hardware cursors solves the problem of cursor disappearance when using certain virtualization technologies, such as VirtualBox
Another Wayland compositors based on wlroots also recommend declaring it (concretely, I've taken the explanation of the commentary from [the LabWC's proposed environment file](https://github.com/labwc/labwc/blob/master/docs/environment))