### PR TITLE
feat: set keyboard from localectl if 01-keyboard.conf does not exist

### DIFF
--- a/community/sway/etc/skel/.config/sway/config.d/XX-keyboard.conf.example
+++ b/community/sway/etc/skel/.config/sway/config.d/XX-keyboard.conf.example
@@ -11,7 +11,7 @@ input * {
     xkb_options grp:caps_toggle,grp_led:caps
     
     # query the available layouts: `localectl list-x11-keymap-layouts`
-    xkb_layout "us,de"
+    xkb_layout "eu,us,de"
 
     # query the available variants for a given layout: `localectl list-x11-keymap-variants de`
     # list in the same order as the layouts - empty equals the default layout

--- a/community/sway/etc/sway/config.d/99-autostart-applications.conf
+++ b/community/sway/etc/sway/config.d/99-autostart-applications.conf
@@ -25,6 +25,8 @@ exec_always {
     '[ -x "$(command -v kanshi)" ] && pkill kanshi; exec kanshi'
     '[ -x "$(command -v playerctl)" ] && pkill playerctl; playerctl -a metadata --format \'{{status}} {{title}}\' --follow | while read line; do pkill -RTMIN+5 waybar; done'
     '[ -x "$(command -v poweralertd)" ] && pkill poweralertd; poweralertd -s -i "line power" &'
+    # apply the keyboard layout from localectl if 01-keyboard.conf has not been set
+    '[ ! -f ~/.config/sway/config.d/01-keyboard.conf ] && /usr/share/sway/scripts/keyboard.sh'
 }
 
 # https://github.com/Alexays/Waybar/issues/1093#issuecomment-841846291

--- a/community/sway/usr/share/sway/scripts/keyboard.sh
+++ b/community/sway/usr/share/sway/scripts/keyboard.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# script that sets the locale from current locale settings
+swaymsg input type:keyboard xkb_layout "$(localectl status | grep "X11 Layout" | sed -e "s/^.*X11 Layout://")"
+
+if localectl status | grep "X11 Variant" ; then
+    swaymsg input type:keyboard xkb_variant "$(localectl status | grep "X11 Variant" | sed -e "s/^.*X11 Variant://")"
+fi


### PR DESCRIPTION
https://github.com/manjaro-sway/manjaro-sway/issues/317

As I see it, we wouldn't even need to update the support.md for this.