### PR TITLE
fix: wob compatibility

### DIFF
--- a/community/sway/etc/sway/definitions
+++ b/community/sway/etc/sway/definitions
@@ -31,7 +31,7 @@ set $term_float footclient -a floating_shell
 set $term_float_portrait footclient -a floating_shell_portrait
 
 # onscreen bar
-set $onscreen_bar bash /usr/share/sway/scripts/wob.sh "$accent-colorFF" "$background-colorFF"
+set $onscreen_bar bash /usr/share/sway/scripts/wob.sh "$accent-color" "$background-color"
 
 # brightness control
 set $brightness_step bash -c 'echo $(( $(light -Mr) / 100 * 5 < 1 ? 1 : $(( $(light -Mr) / 100 * 5 )) ))'

--- a/community/sway/usr/share/sway/scripts/wob.sh
+++ b/community/sway/usr/share/sway/scripts/wob.sh
@@ -19,9 +19,19 @@ wob_pipe=~/.cache/$( basename $SWAYSOCK ).wob
 
 [[ -p $wob_pipe ]] || mkfifo $wob_pipe
 
+ini=~/.config/wob.ini
+
+if [ ! -f "$ini" ]; then
+    echo "anchor = top center" >>$ini
+    echo "margin = 20" >>$ini
+    echo "border_color = ${1:1}" >>$ini
+    echo "bar_color = ${1:1}" >>$ini
+    echo "background_color = ${2:1}" >>$ini
+fi
+
 # wob does not appear in $(swaymsg -t get_msg), so:
 is_running_on_this_screen wob || {
-    tail -f $wob_pipe | wob --border-color $1 --bar-color $1 --background-color $2 --anchor top --anchor center --margin 20 &
+    tail -f $wob_pipe | wob -c $ini &
 }
 
 [[ "$new_value" ]] && echo $new_value > $wob_pipe


### PR DESCRIPTION
a recent wob update removed:

- the required alpha channel
- the command-line parser (instead an ini file is required)