### PR TITLE
feat: allow passing units to weather script

### DIFF
--- a/community/sway/usr/share/sway/templates/waybar/config.jsonc
+++ b/community/sway/usr/share/sway/templates/waybar/config.jsonc
@@ -143,7 +143,7 @@
     "temperature": {
         "critical-threshold": 90,
         "interval": 5,
-        "format": "{icon} {temperatureC}°C",
+        "format": "{icon} {temperatureC}°",
         "format-icons": ["", "", ""],
         "tooltip": false,
         "on-click": "swaymsg exec \"\\$term_float watch sensors\""
@@ -268,7 +268,7 @@
         "format": "{icon} {}",
         "tooltip": true,
         "interval": 3600,
-        // accepts a location as an argument (in quotes)
+        // accepts -c/--city <city> -t/--temperature <C/F> -d/--distance <km/miles>
         "exec": "/usr/share/sway/scripts/weather.py",
         "return-type": "json",
         "format-icons": {


### PR DESCRIPTION
the script now accepts distance units and temperature units as optional parameters.

if LC_MEASUREMENT is set to en_US and if no parameters are passed, is uses imperial units for both, distance and temperature.

I did not know more language codes then en_US which may suggest defaulting to miles/fahrenheit.

closes https://github.com/manjaro-sway/manjaro-sway/issues/203