### PR TITLE
feat: align swayr theme with manjaro config

### DIFF
--- a/community/sway/etc/xdg/swayr/config.toml
+++ b/community/sway/etc/xdg/swayr/config.toml
@@ -4,6 +4,10 @@ args = [
     '-dmenu',
     '-markup-rows',
     '-show-icons',
+    '-no-case-sensitive',
+    '-no-drun-use-desktop-cache',
+    '-p','{prompt}',
+    '-theme-str','* {lightbg: #141a1b; background: #141a1b; lightfg: #16a085; foreground: #eeeeee;}',
 ]
 
 [format]


### PR DESCRIPTION
until we find a nice way to pass the theme differently, this should at least make it look nice in the default config.

![image](https://user-images.githubusercontent.com/4662748/212353448-4d7a0b7a-c4a1-41a3-81a5-2cba012909af.png)

first steps towards closing https://github.com/manjaro-sway/manjaro-sway/issues/417
