### PR TITLE
fix: removing classic repo config from pacman.conf (#1)

### DIFF
--- a/community/sway/usr/bin/manjaro-sway-mirrors
+++ b/community/sway/usr/bin/manjaro-sway-mirrors
@@ -2,7 +2,7 @@
 pacman_conf=/etc/pacman.conf
 custom_conf=/etc/pacman.d/manjaro-sway.repo.conf
 
-if [ "$1" == "check" ]; then
+if [ "$1" = "check" ]; then
     [ -f $custom_conf ] || exit 1
     grep -q "/$(pacman-mirrors -G)" $custom_conf >/dev/null 2>&1 || exit 1
     exit 0
@@ -17,10 +17,10 @@ curl -s https://pkg.manjaro-sway.download/$(pacman-mirrors -G)/ >$custom_conf
 
 ## remove the classic repo config
 if grep -q "\[manjaro-sway\]" $pacman_conf; then
-    echo '## classic repo configuration not present in pacman.conf'
-else
-    sudo sed -i '/\[manjaro-sway\]/,+2 d' $pacman_conf
+    sed -i '/\[manjaro-sway\]/,+2 d' $pacman_conf
     echo '## removed classic repo configuration from pacman.conf'
+else
+    echo '## classic repo configuration not present in pacman.conf'
 fi
 
 ## add a include line to the pacman.conf


### PR DESCRIPTION
The contents of if-else branches for `if grep -q "\[manjaro-sway\]" $pacman_conf;` have been switched.

If `pacman.conf` contains `[manjaro-sway]` then remove it.