### PR TITLE
feat: set a default monospace font

### DIFF
--- a/community/sway/etc/sway/config.d/90-enable-theme.conf
+++ b/community/sway/etc/sway/config.d/90-enable-theme.conf
@@ -5,5 +5,7 @@ exec_always {
   gsettings set org.gnome.desktop.interface font-name "$gui-font"
   gsettings set org.gnome.desktop.interface color-scheme "$gtk-color-scheme"
   gsettings set org.gnome.desktop.input-sources show-all-sources true
+  gsettings set org.gnome.desktop.interface monospace-font-name "$term-font"
+
   kvantummanager --set "$kvantum-theme"
 }


### PR DESCRIPTION
currently there is no default monospace font in manjaro sway, this makes it more consistent.

closes https://github.com/manjaro-sway/manjaro-sway/issues/456