### PR TITLE
Add new window rules for generated windows

### DIFF
--- a/community/sway/etc/sway/config.d/98-application-defaults.conf
+++ b/community/sway/etc/sway/config.d/98-application-defaults.conf
@@ -1,5 +1,15 @@
-#don't show gaps if there's only one window on the desktop
+# don't show gaps if there's only one window on the desktop
 smart_gaps on
+
+# set floating mode for generated windows
+for_window [title="(?:Open|Save) (?:File|Folder|As)"] floating enable;
+for_window [title="(?:Open|Save) (?:File|Folder|As)"] resize set 800 600
+for_window [window_role="pop-up"] floating enable
+for_window [window_role="bubble"] floating enable
+for_window [window_role="task_dialog"] floating enable
+for_window [window_role="Preferences"] floating enable
+for_window [window_type="dialog"] floating enable
+for_window [window_type="menu"] floating enable
 
 # set floating mode for specific applications
 for_window [instance="lxappearance"] floating enable


### PR DESCRIPTION
Many windows (ex popups, menu, dialog boxes, file pickers etc) that are supposed to be floating are not displayed in floating mode. Examples pictures for comparison -->

* Save as dialog

![swappy-20230312_100115](https://user-images.githubusercontent.com/79986754/224524781-55eaed3d-370f-415e-99d5-cd09ee4cc9fa.png)
![swappy-20230312_100234](https://user-images.githubusercontent.com/79986754/224524773-3a0042df-79e3-49e3-923b-5a302474da4e.png)

* Open file dialog

![swappy-20230312_100127](https://user-images.githubusercontent.com/79986754/224524776-ee0a6c0c-de37-44e7-8ea2-2cb6edecd37c.png)
![swappy-20230312_100243](https://user-images.githubusercontent.com/79986754/224524772-5798d64d-8a87-4995-9adc-71650f6afb81.png)