### PR TITLE
Change default font for foot

### DIFF
--- a/community/sway/usr/share/sway/templates/foot.ini
+++ b/community/sway/usr/share/sway/templates/foot.ini
@@ -4,7 +4,7 @@
 term=foot-extra #(or xterm-256color if built with -Dterminfo=disabled)
 # login-shell=no
 
-font=RobotoMono Nerd Font Mono:size=8
+font=MesloLGS NF:size=8
 # font-bold=<bold variant of regular font>
 # font-italic=<italic variant of regular font>
 # font-bold-italic=<bold+italic variant of regular font>


### PR DESCRIPTION
Use ttf-meslo-nerd-font-powerlevel10k as recommended in /usr/share/zsh-theme-powerlevel10k/font.md and https://github.com/romkatv/powerlevel10k#meslo-nerd-font-patched-for-powerlevel10k

Requires package community/ttf-meslo-nerd-font-powerlevel10k

See dicussion https://github.com/manjaro-sway/manjaro-sway/discussions/459