### PR TITLE
fix: adapt to some shellcheck warnings in .profile

### DIFF
--- a/community/sway/etc/skel/.profile
+++ b/community/sway/etc/skel/.profile
@@ -21,18 +21,19 @@ export SHELL=/usr/bin/zsh
 export TERMINAL_COMMAND=/usr/share/sway/scripts/foot.sh
 
 # add default location for zeit.db
-export ZEIT_DB=~/.config/zeit.db
+export ZEIT_DB="$HOME/config/zeit.db"
 
 # Disable hardware cursors. This might fix issues with
 # disappearing cursors
 # export WLR_NO_HARDWARE_CURSORS=1
 
 set -a
-source $HOME/.config/user-dirs.dirs
+. "$HOME/.config/user-dirs.dirs"
 set +a
 
-if [ -n "$(ls $HOME/.config/profile.d 2>/dev/null)" ]; then
-    for f in $HOME/.config/profile.d/*; do
-        source $f
+if [ -n "$(ls "$HOME"/.config/profile.d 2>/dev/null)" ]; then
+    for f in "$HOME"/.config/profile.d/*; do
+        # shellcheck source=/dev/null
+        . "$f"
     done
 fi


### PR DESCRIPTION
"source" is undefined in POSIX sh
double quote variables
consistently use "$HOME" instead of "~"