### PR TITLE
Update community/sway/etc/skel/.profile

### DIFF
--- a/community/sway/etc/skel/.profile
+++ b/community/sway/etc/skel/.profile
@@ -25,7 +25,10 @@ export ZEIT_DB="$HOME/config/zeit.db"
 
 # Disable hardware cursors. This might fix issues with
 # disappearing cursors
-# export WLR_NO_HARDWARE_CURSORS=1
+if systemd-detect-virt -q; then
+    # if the system is running inside a virtual machine, disable hardware cursors
+    export WLR_NO_HARDWARE_CURSORS=1
+fi
 
 set -a
 . "$HOME/.config/user-dirs.dirs"


### PR DESCRIPTION
Manjaro Sway cannot run normally in a virtual machine environment after version manjaro-sway-22.0.4-230423-linux61, unable to see the graphical interface. 
After testing, the code `export WLR_NO_HARDWARE_CURSORS=1` is required in a virtual machine environment.
I added the `systemd-detect-virt -q` condition to determine whether it is a virtual machine environment. After this, both the virtual machine and the physical machine can work normally.