### PR TITLE
Remove floating shell window size

### DIFF
--- a/community/sway/etc/sway/definitions
+++ b/community/sway/etc/sway/definitions
@@ -31,7 +31,7 @@ set $once /usr/share/sway/scripts/once.sh
 # Your preferred terminal emulator
 set $term /usr/share/sway/scripts/foot.sh
 set $term_cwd $term -D "$(swaycwd 2>/dev/null || echo $HOME)"
-set $term_float footclient --app-id floating_shell --window-size-chars 82x25
+set $term_float footclient --app-id floating_shell
 
 # onscreen bar
 set $onscreen_bar /usr/share/sway/scripts/wob.sh "$accent-color" "$background-color"


### PR DESCRIPTION
Can lead to rounding issues with `foot --server` if windows are scaled (scaling factor 1.5 in my case):
```
warn: server.c:72: client FD=8: terminal still alive
 err: wayland.c:1980: failed to roundtrip Wayland display: Broken pipe
 err: wayland.c:1980: failed to roundtrip Wayland display: Broken pipe
 err: wayland.c:1980: failed to roundtrip Wayland display: Broken pipe
 err: wayland.c:1945: failed to flush wayland socket: Broken pipe
```