### PR TITLE
fix: Quote $focus_after_move to avoid shell syntax errors when unset

### DIFF
--- a/community/sway/etc/sway/modes/default
+++ b/community/sway/etc/sway/modes/default
@@ -114,7 +114,7 @@ $bindsym $mod+8 workspace $ws8
 $bindsym $mod+9 workspace $ws9
 $bindsym $mod+0 workspace $ws10
 
-set $focus_ws [ $focus_after_move == 'true' ] && swaymsg workspace
+set $focus_ws [ "$focus_after_move" == 'true' ] && swaymsg workspace
 
 ## Action // Move focused window to workspace // $mod + Shift + [number] ##
 $bindsym $mod+Shift+1 move container to workspace $ws1, exec $focus_ws $ws1


### PR DESCRIPTION
I noticed some shell syntax errors showing up in `sway.log`, after configuring a sway session with `--verbose --debug` logging flags via `tuigreet` for debugging my custom user sway configs.

sway.log error message was:

    97:59:38.010 [INFO] [sway/commands.c:261] Handling command 'exec [ $focus_after_move == 'true' ] && swaymsg workspace number 4'
    97:59:38.010 [DEBUG] [sway/commands/exec_always.c:58] Executing [ $focus_after_move == 'true' ] && swaymsg workspace number 4
    97:59:38.017 [DEBUG] [sway/commands/exec_always.c:111] Child process created with pid 3079587
    97:59:38.017 [DEBUG] [sway/commands/exec_always.c:113] Recording workspace for process 3079587
    97:59:38.017 [DEBUG] [sway/desktop/transaction.c:398] Transaction 0x556c7501db60 committing with 25 instructions
    sh: line 1: [: ==: unary operator expected
                ^----^ SC2086: Note that this var was null, so we get syntax error


(modified) Shellcheck warning was:

    In community/sway/etc/sway/modes/default line 117:
    set $focus_ws [ $focus_after_move == 'true' ] && swaymsg workspace
                    ^---------------^ SC2154 (warning): focus_after_move is referenced but not assigned.
                    ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

    Did you mean:
    set $focus_ws [ "$focus_after_move" == 'true' ] && swaymsg workspace


## How to Reproduce

1. Just press any `$mod1+N` keyboard shortcut to switch workspaces while `$focus_after_move` is unset / null.
  - Example: <kbd>Super_L</kbd> + <kbd>1</kbd>

### To ensure seeing the message in logs:

Create a new sway session file in: `/usr/share/wayland-sessions/sway-unsupported-debug.desktop`
Containing:

```desktop
[Desktop Entry]
Name=Sway (unsupported GPU) DEBUG LOGGING
Comment=An i3-compatible Wayland compositor
Exec=sway --verbose --debug --unsupported-gpu 1>/tmp/sway.log 2>&1
Type=Application
```

1. Logout to `greetd` / `tuigreet`
2. Press <kbd>F3</kbd>
3. Select the sway session labeled: `Sway (unsupported GPU) DEBUG LOGGING`
4. After sway starts the desktop session, follow reproduction steps and check `/tmp/sway.log` for the error message.