### PR TITLE
Update sbdp.py to expand env variables

### DIFF
--- a/community/sway/usr/share/sway/scripts/sbdp.py
+++ b/community/sway/usr/share/sway/scripts/sbdp.py
@@ -2,6 +2,7 @@
 import sys
 import glob
 import re
+import os
 from typing import Text
 import json
 
@@ -26,6 +27,7 @@ def readFile(filePath):
     for line in allLines:
         if re.search(r'^include\s+(.+?)$', line):
             nextPath = re.findall(r'^include\s+(.+?)$', line)[0]
+            nextPath = os.path.expandvars(nextPath)
             finalLines = finalLines + readFile(nextPath)
         else:
             finalLines = finalLines + [line]


### PR DESCRIPTION
Currently sbdp requires sway config files to not use environment variables, which sway instead can use.  
This brings it closer to the native sway config parsing behaviour.