### PR TITLE
fix shutdown command

### DIFF
--- a/community/sway/etc/sway/modes/shutdown
+++ b/community/sway/etc/sway/modes/shutdown
@@ -25,7 +25,7 @@ mode --pango_markup $mode_shutdown {
     $bindsym h mode "default", exec systemctl hibernate
 
     # shutdown
-    $bindsym s exec $purge_cliphist; exec systemctl shutdown
+    $bindsym s exec $purge_cliphist; exec systemctl poweroff
 
     # reboot
     $bindsym r exec $purge_cliphist; exec systemctl reboot


### PR DESCRIPTION
`systemctl shutdown` results in:

> Unknown command verb shutdown.

`systemctl poweroff` should be the correct command.