### PR TITLE
Include firefox to inhibit idle in fullscreen

### DIFF
--- a/community/sway/etc/sway/config.d/98-application-defaults.conf
+++ b/community/sway/etc/sway/config.d/98-application-defaults.conf
@@ -34,6 +34,7 @@ for_window [app_id="microsoft teams - preview"] inhibit_idle fullscreen
 for_window [app_id="google-chrome"] inhibit_idle fullscreen
 for_window [app_id="google-chrome-beta"] inhibit_idle fullscreen
 for_window [app_id="google-chrome-unstable"] inhibit_idle fullscreen
+for_window [app_id="firefox"] inhibit_idle fullscreen
 
 # Don't allow applications to inhibit shortcuts, i.e. grab total control of the
 # keyboard. Chrome currently abuses this by enabling it for all "--app=..."


### PR DESCRIPTION
Firefox is the default web browser in manjaro-sway. Currently, swaylock locks the screen when playing videos in fullscreen mode. 

Here, firefox is included in the list of programs that inhibit locking the screen when in fullscreen.