### PR TITLE
Update shutdown

### DIFF
--- a/community/sway/etc/sway/modes/shutdown
+++ b/community/sway/etc/sway/modes/shutdown
@@ -21,9 +21,6 @@ mode --pango_markup $mode_shutdown {
     # suspend
     $bindsym u mode "default", exec systemctl suspend
 
-    # hibernate
-    $bindsym h mode "default", exec systemctl hibernate
-
     # shutdown
     $bindsym s exec $purge_cliphist; exec systemctl poweroff
 


### PR DESCRIPTION
Removed hibernate option in shutdown mode.

Out of the box hibernation does not work in manjaro-sway. E.g., there is no swap after a fresh install and the resume hook is not set.