### PR TITLE
Fix for manjaro-sway/manjaro-sway#623

### DIFF
--- a/community/sway/usr/share/sway/scripts/waybar.sh
+++ b/community/sway/usr/share/sway/scripts/waybar.sh
@@ -12,4 +12,4 @@ if [ -f "$USER_STYLE_PATH" ]; then
     USER_STYLE=$USER_STYLE_PATH
 fi
 
-waybar -c "${USER_CONFIG:-"/usr/share/sway/templates/waybar/config.jsonc"}" -s "${USER_STYLE:-"/usr/share/sway/templates/waybar/style.css"}" >/tmp/waybar.log &
+waybar -c "${USER_CONFIG:-"/usr/share/sway/templates/waybar/config.jsonc"}" -s "${USER_STYLE:-"/usr/share/sway/templates/waybar/style.css"}" > $(mktemp -t XXXX.waybar.log) &


### PR DESCRIPTION
This is a fix for manjaro-sway/manjaro-sway#623 as I saw that same behavior in addition to the one below.

I needed to start multiple sway sessions on different ttys. When doing so, sway would refuse to run due to swaybar. After some debugging, I tracked down the source to being a file that couldn't be written. This test vm I created has two users: manjaro & test

When you first login, the `waybar.sh` attempts to log by creating a `/tmp/waybar.log` file with permissions that only allow that specific user to read/write. If you logout and then attempt to login with another user, you'll find that the swaybar will refuse to load at all. You won't find errors there as it can't write to the file. A reboot will fix it as the /tmp directory will be cleared.

```
-rw-r--r-- 1 manjaro manjaro 904 Feb 13 00:00 waybar.log
```

The fix will create a random temp file for each login session, preventing the permission problem:
```
-rw------- 1 manjaro manjaro 904 Feb 13 00:15 yezY.waybar.log
-rw------- 1 test    test    904 Feb 13 00:10 BKAI.waybar.log
```

After implementing the fix on several machines, I no longer have to reload the swaybar on login or have any issues with using multiple ttys
