### PR TITLE
Wait for xdg-desktop-portal to start before launching waybar

### DIFF
--- a/community/sway/usr/share/sway/scripts/waybar.sh
+++ b/community/sway/usr/share/sway/scripts/waybar.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
 # wrapper script for waybar with args, see https://github.com/swaywm/sway/issues/5724
 
+WAYBAR_LOG=/tmp/waybar.$USER.log
+>$WAYBAR_LOG
+
 USER_CONFIG_PATH=$HOME/.config/waybar/config.jsonc
 USER_STYLE_PATH=$HOME/.config/waybar/style.css
+
+while ! pgrep -U $USER -f xdg-desktop-portal >/dev/null; do
+    date +"[%Y-%m-%d %T.%3N] Waiting for xdg-desktop-portal to start..." >> $WAYBAR_LOG
+    sleep 0.1
+done
 
 if [ -f "$USER_CONFIG_PATH" ]; then
     USER_CONFIG=$USER_CONFIG_PATH
@@ -12,4 +20,4 @@ if [ -f "$USER_STYLE_PATH" ]; then
     USER_STYLE=$USER_STYLE_PATH
 fi
 
-waybar -c "${USER_CONFIG:-"/usr/share/sway/templates/waybar/config.jsonc"}" -s "${USER_STYLE:-"/usr/share/sway/templates/waybar/style.css"}" > $(mktemp -t XXXX.waybar.log) &
+waybar -c "${USER_CONFIG:-"/usr/share/sway/templates/waybar/config.jsonc"}" -s "${USER_STYLE:-"/usr/share/sway/templates/waybar/style.css"}" >> $WAYBAR_LOG &


### PR DESCRIPTION
This is a follow up from my previous pull request which fixed an issue with the waybar not launching due to the log file not being writable. When I installed manjaro on a different computer I noticed it started having the same problem and tried it again in a virtual machine.

In the virtual machine, the following behavior was noticed:
- Sway bar wouldn't be running and reloading would cause it to load
- Only occurred after a reboot when all the processes were killed

This lead me to test with strace, pstree, and sway in logging mode by launching sway with logging. I have attached both pre and post fix logs. It seems that the waybar has a race condition. I tried with a few difference processes (comparing before and after fix) and found that `xdg-desktop-portal` was one of the most reliable to wait on. 

I don't know enough about sway and how it interacts with wayland to understand why we have to wait about .5 seconds (originally tried with sleep which let me to check pstree both before and after a "reload") for the swaybar to load successfully.

The strace from pre-fix shows the following at the end of the log:
```
--- SIGRT_8 {si_signo=SIGRT_8, si_code=SI_USER, si_pid=1810, si_uid=1000} ---
+++ killed by SIGRT_8 +++
```

I put `*** ENDING` in the logs to indicate I was doing a logout to separate any noise from the logout itself. If you logout and login again, it seems to work as several of the processes are already running, which is why I opted to wait for a process instead of a sleep. 

[waybar-logs.tar.gz](https://github.com/manjaro-sway/desktop-settings/files/14326180/waybar-logs.tar.gz)