### PR TITLE
:zap: Start waybar via systemd

### DIFF
--- a/community/sway/etc/sway/config.d/96-waybar-config.conf
+++ b/community/sway/etc/sway/config.d/96-waybar-config.conf
@@ -1,5 +1,4 @@
 bar {
     id default
-    swaybar_command $statusbar
     position $waybar_position
 }

--- a/community/sway/etc/sway/config.d/99-autostart-applications.conf
+++ b/community/sway/etc/sway/config.d/99-autostart-applications.conf
@@ -19,6 +19,7 @@ exec {
     $initialize_swayr_daemon
     $initialize_poweralert_daemon
     $initialize_idlehack_daemon
+    $initialize_waybar
 }
 
 exec_always {

--- a/community/sway/etc/sway/definitions
+++ b/community/sway/etc/sway/definitions
@@ -92,7 +92,6 @@ include /etc/sway/autostart
 seat seat0 hide_cursor 5000
 
 # statusbar command
-set $statusbar /usr/share/sway/scripts/waybar.sh
 set $waybar_position top
 
 # pulseaudio command

--- a/community/sway/etc/systemd/user/waybar.service
+++ b/community/sway/etc/systemd/user/waybar.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Highly customizable Wayland bar for Sway and Wlroots based compositors.
+Documentation=https://github.com/Alexays/Waybar/wiki/
+PartOf=sway-session.target
+After=sway-session.target
+Requisite=sway-session.target
+
+[Service]
+ExecStart=/usr/share/sway/scripts/waybar.sh
+ExecReload=kill -SIGUSR2 $MAINPID
+Restart=on-failure
+
+[Install]
+WantedBy=sway-session.target

--- a/community/sway/usr/share/sway/scripts/waybar.sh
+++ b/community/sway/usr/share/sway/scripts/waybar.sh
@@ -12,4 +12,4 @@ if [ -f "$USER_STYLE_PATH" ]; then
     USER_STYLE=$USER_STYLE_PATH
 fi
 
-waybar -c "${USER_CONFIG:-"/usr/share/sway/templates/waybar/config.jsonc"}" -s "${USER_STYLE:-"/usr/share/sway/templates/waybar/style.css"}" > $(mktemp -t XXXX.waybar.log) &
+waybar -c "${USER_CONFIG:-"/usr/share/sway/templates/waybar/config.jsonc"}" -s "${USER_STYLE:-"/usr/share/sway/templates/waybar/style.css"}" > $(mktemp -t XXXX.waybar.log)


### PR DESCRIPTION
Adds a systemd unit for waybar, so it starts after the sway session is started. This could be the start of many more systemd units.

relates to https://github.com/manjaro-sway/manjaro-sway/issues/653

closes https://github.com/manjaro-sway/manjaro-sway/issues/623
superseeds https://github.com/manjaro-sway/desktop-settings/pull/184