### PR TITLE
fix: missing weather widget on waybar

### DIFF
--- a/community/sway/usr/share/sway/scripts/weather.py
+++ b/community/sway/usr/share/sway/scripts/weather.py
@@ -83,13 +83,11 @@ WWO_CODE = {
     "395": "HeavySnowShowers",
 }
 
+current_locale = (os.environ.get('LC_MEASUREMENT') or "en_GB").split('.')[0]
 data = {}
 city = ""
 temperature = "C"
 distance = "km"
-
-if os.environ['LC_MEASUREMENT']:
-    current_locale = os.environ['LC_MEASUREMENT'].split('.')[0]
 
 if current_locale == "en_US":
     temperature = "F"

--- a/community/sway/usr/share/sway/scripts/weather.py
+++ b/community/sway/usr/share/sway/scripts/weather.py
@@ -3,6 +3,7 @@
 # credits: @bjesus https://gist.github.com/bjesus/f8db49e1434433f78e5200dc403d58a3
 
 import json
+import locale
 import os
 import requests
 import sys
@@ -83,7 +84,9 @@ WWO_CODE = {
     "395": "HeavySnowShowers",
 }
 
-current_locale = (os.environ.get('LC_MEASUREMENT') or "en_GB").split('.')[0]
+# see https://docs.python.org/3/library/locale.html#background-details-hints-tips-and-caveats
+locale.setlocale(locale.LC_ALL, '')
+current_locale, _ = locale.getlocale(locale.LC_CTYPE)
 data = {}
 city = ""
 temperature = "C"


### PR DESCRIPTION
During the clean installation, I encountered a problem that the weather widget is not displayed.
When restarting the waybar, the trace returned:
```
Traceback (most recent call last):
  File "/usr/share/sway/scripts/weather.py", line 91, in <module>
    if os.environ['LC_MEASUREMENT']:
       ~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "<frozen os>", line 679, in __getitem__
KeyError: 'LC_MEASUREMENT'
```

Based on the metric system, I assigned the default locale en_GB by default.