### PR TITLE
fix(sway): Propagate wrapper script arguments to sway

### DIFF
--- a/community/sway/usr/local/bin/sway
+++ b/community/sway/usr/local/bin/sway
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if lsmod | grep nvidia; then
-    /usr/bin/sway --unsupported-gpu
+    /usr/bin/sway --unsupported-gpu "$@"
 else
-    /usr/bin/sway
+    /usr/bin/sway "$@"
 fi


### PR DESCRIPTION
:bug: The new wrapper script for sway currently does not allow passing arguments down to the real `sway` binary.

This PR fixes the issue by propagating all shell arguments (e.g. passing `"$@"`) to the `/usr/bin/sway` binary.  This re-enables functionality such as passing flags `--debug` and `--verbose` from a display manager that launches a custom Sway desktop session.