### PR TITLE
Remove double quotes from sunset.sh latitude and longitude

### DIFF
--- a/community/sway/usr/share/sway/scripts/sunset.sh
+++ b/community/sway/usr/share/sway/scripts/sunset.sh
@@ -18,9 +18,9 @@ start() {
         if [ -z ${longitude+x} ] || [ -z ${latitude+x} ]; then
             GEO_CONTENT=$(curl -sL https://manjaro-sway.download/geoip)
         fi
-        longitude=${longitude:-$(echo "$GEO_CONTENT" | jq '.longitude // empty')}
+        longitude=${longitude:-$(echo "$GEO_CONTENT" | jq -r '.longitude // empty')}
         longitude=${longitude:-$fallback_longitude}
-        latitude=${latitude:-$(echo "$GEO_CONTENT" | jq '.latitude // empty')}
+        latitude=${latitude:-$(echo "$GEO_CONTENT" | jq -r '.latitude // empty')}
         latitude=${latitude:-$fallback_latitude}
 
         echo longitude: "$longitude" latitude: "$latitude"


### PR DESCRIPTION
sunset.sh was passing in the latitude and longitude with an extra pair of single quotes, resulting in wlsunset using the wrong location.

Running the sunset script with `set -o xtrace` and `bash -c "source sunset.sh; start`,
```
{"alt":"off","tooltip":"no gamma correction"}
longitude: "-79.35030" latitude: "43.78060"
+ wlsunset -l '"43.78060"' -L '"-79.35030"' -t 3800 -T 6500 -d 900
registry: adding output 49                                                            
calculated sun trajectory: dawn 01:30, sunrise 02:04, sunset 13:48, dusk 14:21
setting temperature on output '49' to 3800 K
```
the command has extra quotes in `-l '"43.78060"' -L '"-79.35030"'`, so wlsunset gets the wrong sun trajectory times.

After stripping the extra quotes,
```
{"alt":"off","tooltip":"no gamma correction"}
longitude: -79.35030 latitude: 43.78060
+ wlsunset -l 43.78060 -L -79.35030 -t 3800 -T 6500 -d 900
registry: adding output 49                                                                                                                                                    
calculated sun trajectory: dawn 05:12, sunrise 06:03, sunset 20:24, dusk 21:15
setting temperature on output '49' to 6500 K
```
the command is correct.
