### PR TITLE
Add default scale output for display

### DIFF
--- a/community/sway/etc/sway/definitions
+++ b/community/sway/etc/sway/definitions
@@ -48,6 +48,7 @@ set $brightness_down $brightness down | $onscreen_bar
 # scaling
 set $scale_up /usr/share/sway/scripts/scale.sh up
 set $scale_down /usr/share/sway/scripts/scale.sh down
+set $scale_default /usr/share/sway/scripts/scale.sh default
 
 # audio control
 set $sink_volume pactl get-sink-volume @DEFAULT_SINK@ | grep '^Volume:' | cut -d / -f 2 | tr -d ' ' | sed 's/%//'

--- a/community/sway/etc/sway/modes/default
+++ b/community/sway/etc/sway/modes/default
@@ -167,6 +167,9 @@ $bindsym $alt_mod+plus exec $scale_up
 ## Action // Scale down  ##
 $bindsym $alt_mod+minus exec $scale_down
 
+## Action // Scale default  ##
+$bindsym $mod+equal exec $scale_default
+
 ## Action // Toggle floating ##
 $bindsym $mod+Shift+space floating toggle
 

--- a/community/sway/usr/share/sway/scripts/scale.sh
+++ b/community/sway/usr/share/sway/scripts/scale.sh
@@ -28,5 +28,9 @@ case $1'' in
     next_scale=$(echo "$(current_scale) - $increment" | bc)
     scale
     ;;
+'default')
+    next_scale=1
+    scale
+    ;;
 esac
 


### PR DESCRIPTION
Entering `$mod+equal` sets the display output to the default scale