### PR TITLE
Fix manjaro-sway/manjaro-sway#835 - pkill only the help.sh nwg-wrapper instance

### DIFF
--- a/community/sway/usr/share/sway/scripts/help.sh
+++ b/community/sway/usr/share/sway/scripts/help.sh
@@ -13,11 +13,11 @@ if [ "$1" = "--toggle" ]; then
         touch "$LOCKFILE"
     fi
     # toggles the visibility
-    pkill -f -${VISIBILITY_SIGNAL} nwg-wrapper
+    pkill -f -${VISIBILITY_SIGNAL} 'nwg-wrapper.*-s help.sh'
 
 else
     # makes sure no "old" wrappers are mounted (on start and reload)
-    pkill -f -${QUIT_SIGNAL} nwg-wrapper
+    pkill -f -${QUIT_SIGNAL} 'nwg-wrapper.*-s help.sh'
     # mounts the wrapper to all outputs
     for output in $(swaymsg -t get_outputs --raw | jq -r '.[].name'); do
         # sets the initial visibility


### PR DESCRIPTION
This change fixes manjaro-sway/manjaro-sway#835.

Only signal the `nwg-wrapper` instance that is running `help.sh`, selected using RegEx:

    'nwg-wrapper.*-s help.sh'

closes manjaro-sway/manjaro-sway#835