### PR TITLE
theme: Nordic-bluish-accent / theme.conf

### DIFF
--- a/community/sway/usr/share/sway/templates/waybar/style.css
+++ b/community/sway/usr/share/sway/templates/waybar/style.css
@@ -193,6 +193,10 @@ window#waybar {
     color: @error_color;
 }
 
+#workspaces button:hover {
+    color: @theme_bg_color;
+}
+
 #custom-pacman {
     color: @warning_color;
 }

--- a/community/sway/usr/share/sway/themes/nordic-bluish-accent/foot-theme.ini
+++ b/community/sway/usr/share/sway/themes/nordic-bluish-accent/foot-theme.ini
@@ -1,0 +1,22 @@
+include=/usr/share/sway/templates/foot.ini
+
+[colors]
+alpha=0.8
+foreground=eeeeee
+background=2E3440
+regular0=2E3440  # black
+regular1=BF616A  # red
+regular2=A3BE8C  # green
+regular3=EBCB8B  # yellow
+regular4=5E81AC  # blue
+regular5=B48EAD  # magenta
+regular6=88C0D0  # cyan
+regular7=E5E9F0  # white
+bright0=4C566A   # bright black
+bright1=D08770   # bright red
+bright2=A3BE8C   # bright green
+bright3=EBCB8B   # bright yellow
+bright4=81A1C1   # bright blue
+bright5=B48EAD   # bright magenta
+bright6=88C0D0   # bright cyan
+bright7=ECEFF4   # bright white

--- a/community/sway/usr/share/sway/themes/nordic-bluish-accent/packages
+++ b/community/sway/usr/share/sway/themes/nordic-bluish-accent/packages
@@ -1,0 +1,6 @@
+nordzy-icon-theme
+nordzy-cursors
+nordic-bluish-accent-theme
+utterly-nord-plasma
+ttf-roboto
+ttf-jetbrains-mono-nerd  

--- a/community/sway/usr/share/sway/themes/nordic-bluish-accent/theme.conf
+++ b/community/sway/usr/share/sway/themes/nordic-bluish-accent/theme.conf
@@ -1,0 +1,43 @@
+# based on Base16 Seti UI
+# Author: juleslink
+
+# some global theme specific variables
+set $gtk-theme  Nordic-bluish-accent
+set $icon-theme Nordzy-dark
+set $cursor-theme Nordzy
+set $gui-font Roboto 11
+set $term-font JetBrainsMono NF
+set $gtk-color-scheme prefer-dark
+set $kvantum-theme Utterly-Nord
+
+# a theme specific color map
+set $color0 #2E3440
+set $color1 #3B4252
+set $color2 #5E81AC
+set $color3 #8FBCBB
+set $color4 #88C0D0
+set $color5 #D8DEE9
+set $color6 #E5E9F0
+set $color7 #ECEFF4
+set $color8 #BF616A
+set $color9 #D08770
+set $color10 #EBCB8B
+set $color11 #A3BE8C
+set $color12 #8FBCBB
+set $color13 #81A1C1
+set $color14 #B48EAD
+set $color15 #8a553f
+
+set $background-color $color0
+set $text-color $color6
+set $selection-color $color1
+set $accent-color $color13
+
+# Basic color configuration using the Base16 variables for windows and borders.
+# Property Name         Border   BG       Text    Indicator Child Border
+client.focused          $color13 $color13 $color0 $color13  $color13
+client.focused_inactive $color1  $color1  $color5 $color3   $color1
+client.unfocused        $color1  $color0  $color5 $color1   $color1
+client.urgent           $color8  $color8  $color0 $color8   $color8
+client.placeholder      $color0  $color0  $color5 $color0   $color0
+client.background       $color7


### PR DESCRIPTION
Nordic-bluish-accent Theme

![swappy-20240817_005237](https://github.com/user-attachments/assets/40b45909-d243-4010-b2f6-cbc0302fb44d)



this needs also 

#workspaces button:hover {
    color: @theme_bg_color;
}

in 
waybar/style.css

which is not needed by any matcha theme

maybe there is a better way to do this 