### PR TITLE
feat/catppuccin themes

### DIFF
--- a/community/sway/usr/share/sway/templates/waybar/style.css
+++ b/community/sway/usr/share/sway/templates/waybar/style.css
@@ -50,8 +50,8 @@
 
 /* The whole bar */
 window#waybar {
-    background: @theme_bg_color;
-    color: @wm_icon_bg;
+    background: @theme_base_color;
+    color: @theme_text_color;
     font-size: 14px;
 }
 

--- a/community/sway/usr/share/sway/themes/catppuccin-frappe/foot-theme.ini
+++ b/community/sway/usr/share/sway/themes/catppuccin-frappe/foot-theme.ini
@@ -1,0 +1,40 @@
+include=/usr/share/sway/templates/foot.ini
+
+# ref.: https://github.com/catppuccin/foot/blob/962ff1a5b6387bc5419e9788a773a080eea5f1e1/themes/catppuccin-frappe.ini
+
+[cursor]
+color=232634 f2d5cf
+
+[colors]
+foreground=c6d0f5
+background=303446
+
+regular0=51576d
+regular1=e78284
+regular2=a6d189
+regular3=e5c890
+regular4=8caaee
+regular5=f4b8e4
+regular6=81c8be
+regular7=b5bfe2
+
+bright0=626880
+bright1=e78284
+bright2=a6d189
+bright3=e5c890
+bright4=8caaee
+bright5=f4b8e4
+bright6=81c8be
+bright7=a5adce
+
+16=ef9f76
+17=f2d5cf
+
+selection-foreground=c6d0f5
+selection-background=4f5369
+
+search-box-no-match=232634 e78284
+search-box-match=c6d0f5 414559
+
+jump-labels=232634 ef9f76
+urls=8caaee

--- a/community/sway/usr/share/sway/themes/catppuccin-frappe/packages
+++ b/community/sway/usr/share/sway/themes/catppuccin-frappe/packages
@@ -1,0 +1,4 @@
+catppuccin-gtk-theme-frappe
+kvantum-theme-catppuccin-git
+ttf-jetbrains-mono-nerd
+ttf-roboto

--- a/community/sway/usr/share/sway/themes/catppuccin-frappe/theme.conf
+++ b/community/sway/usr/share/sway/themes/catppuccin-frappe/theme.conf
@@ -1,0 +1,50 @@
+# catppuccin-frappe
+
+# some global theme specific variables
+set $gtk-theme catppuccin-frappe-blue-standard+default 
+set $icon-theme catppuccin-frappe-blue-standard+default
+set $gui-font Roboto 11
+set $term-font JetBrainsMono NF
+set $gtk-color-scheme prefer-dark
+set $kvantum-theme catppuccin-frappe-blue
+set $background $HOME/.config/sway/generated_background.svg
+
+set $rosewater #f2d5cf
+set $flamingo #eebebe
+set $pink #f4b8e4
+set $mauve #ca9ee6
+set $red #e78284
+set $maroon #ea999c
+set $peach #ef9f76
+set $yellow #e5c890
+set $green #a6d189
+set $teal #81c8be
+set $sky #99d1db
+set $sapphire #85c1dc
+set $blue #8caaee
+set $lavender #babbf1
+set $text #c6d0f5
+set $subtext1 #b5bfe2
+set $subtext0 #a5adce
+set $overlay2 #949cbb
+set $overlay1 #838ba7
+set $overlay0 #737994
+set $surface2 #626880
+set $surface1 #51576d
+set $surface0 #414559
+set $base #303446
+set $mantle #292c3c
+set $crust #232634
+
+set $background-color $base
+set $text-color $text
+set $selection-color $color1
+set $accent-color $blue
+
+# target                 title     bg    text   indicator  border
+client.focused           $lavender $base $text  $rosewater $lavender
+client.focused_inactive  $overlay0 $base $text  $rosewater $overlay0
+client.unfocused         $overlay0 $base $text  $rosewater $overlay0
+client.urgent            $peach    $base $peach $overlay0  $peach
+client.placeholder       $overlay0 $base $text  $overlay0  $overlay0
+client.background        $base

--- a/community/sway/usr/share/sway/themes/catppuccin-latte/foot-theme.ini
+++ b/community/sway/usr/share/sway/themes/catppuccin-latte/foot-theme.ini
@@ -1,0 +1,40 @@
+include=/usr/share/sway/templates/foot.ini
+
+# ref.: https://github.com/catppuccin/foot/blob/962ff1a5b6387bc5419e9788a773a080eea5f1e1/themes/catppuccin-latte.ini
+
+[cursor]
+color=eff1f5 dc8a78
+
+[colors]
+foreground=4c4f69
+background=eff1f5
+
+regular0=5c5f77
+regular1=d20f39
+regular2=40a02b
+regular3=df8e1d
+regular4=1e66f5
+regular5=ea76cb
+regular6=179299
+regular7=acb0be
+
+bright0=6c6f85
+bright1=d20f39
+bright2=40a02b
+bright3=df8e1d
+bright4=1e66f5
+bright5=ea76cb
+bright6=179299
+bright7=bcc0cc
+
+16=fe640b
+17=dc8a78
+
+selection-foreground=4c4f69
+selection-background=ccced7
+
+search-box-no-match=dce0e8 d20f39
+search-box-match=4c4f69 ccd0da
+
+jump-labels=dce0e8 fe640b
+urls=1e66f5

--- a/community/sway/usr/share/sway/themes/catppuccin-latte/packages
+++ b/community/sway/usr/share/sway/themes/catppuccin-latte/packages
@@ -1,0 +1,4 @@
+catppuccin-gtk-theme-latte
+kvantum-theme-catppuccin-git
+ttf-jetbrains-mono-nerd
+ttf-roboto

--- a/community/sway/usr/share/sway/themes/catppuccin-latte/theme.conf
+++ b/community/sway/usr/share/sway/themes/catppuccin-latte/theme.conf
@@ -1,0 +1,50 @@
+# catppuccin-latte
+
+# some global theme specific variables
+set $gtk-theme catppuccin-latte-blue-standard+default 
+set $icon-theme catppuccin-latte-blue-standard+default
+set $gui-font Roboto 11
+set $term-font JetBrainsMono NF
+set $gtk-color-scheme prefer-light
+set $kvantum-theme catppuccin-latte-blue
+set $background $HOME/.config/sway/generated_background.svg
+
+set $rosewater #dc8a78
+set $flamingo #dd7878
+set $pink #ea76cb
+set $mauve #8839ef
+set $red #d20f39
+set $maroon #e64553
+set $peach #fe640b
+set $yellow #df8e1d
+set $green #40a02b
+set $teal #179299
+set $sky #04a5e5
+set $sapphire #209fb5
+set $blue #1e66f5
+set $lavender #7287fd
+set $text #4c4f69
+set $subtext1 #5c5f77
+set $subtext0 #6c6f85
+set $overlay2 #7c7f93
+set $overlay1 #8c8fa1
+set $overlay0 #9ca0b0
+set $surface2 #acb0be
+set $surface1 #bcc0cc
+set $surface0 #ccd0da
+set $base #eff1f5
+set $mantle #e6e9ef
+set $crust #dce0e8
+
+set $background-color $base
+set $text-color $text
+set $selection-color $color1
+set $accent-color $blue
+
+# target                 title     bg    text   indicator  border
+client.focused           $lavender $base $text  $rosewater $lavender
+client.focused_inactive  $overlay0 $base $text  $rosewater $overlay0
+client.unfocused         $overlay0 $base $text  $rosewater $overlay0
+client.urgent            $peach    $base $peach $overlay0  $peach
+client.placeholder       $overlay0 $base $text  $overlay0  $overlay0
+client.background        $base

--- a/community/sway/usr/share/sway/themes/catppuccin-macchiato/foot-theme.ini
+++ b/community/sway/usr/share/sway/themes/catppuccin-macchiato/foot-theme.ini
@@ -1,0 +1,40 @@
+include=/usr/share/sway/templates/foot.ini
+
+# ref.: https://github.com/catppuccin/foot/blob/962ff1a5b6387bc5419e9788a773a080eea5f1e1/themes/catppuccin-macchiato.ini
+
+[cursor]
+color=181926 f4dbd6
+
+[colors]
+foreground=cad3f5
+background=24273a
+
+regular0=494d64
+regular1=ed8796
+regular2=a6da95
+regular3=eed49f
+regular4=8aadf4
+regular5=f5bde6
+regular6=8bd5ca
+regular7=b8c0e0
+
+bright0=5b6078
+bright1=ed8796
+bright2=a6da95
+bright3=eed49f
+bright4=8aadf4
+bright5=f5bde6
+bright6=8bd5ca
+bright7=a5adcb
+
+16=f5a97f
+17=f4dbd6
+
+selection-foreground=cad3f5
+selection-background=454a5f
+
+search-box-no-match=181926 ed8796
+search-box-match=cad3f5 363a4f
+
+jump-labels=181926 f5a97f
+urls=8aadf4

--- a/community/sway/usr/share/sway/themes/catppuccin-macchiato/packages
+++ b/community/sway/usr/share/sway/themes/catppuccin-macchiato/packages
@@ -1,0 +1,4 @@
+catppuccin-gtk-theme-macchiato
+kvantum-theme-catppuccin-git
+ttf-jetbrains-mono-nerd
+ttf-roboto

--- a/community/sway/usr/share/sway/themes/catppuccin-macchiato/theme.conf
+++ b/community/sway/usr/share/sway/themes/catppuccin-macchiato/theme.conf
@@ -1,4 +1,4 @@
-# catppuccin-macchiato 
+# catppuccin-macchiato
 
 # some global theme specific variables
 set $gtk-theme catppuccin-macchiato-blue-standard+default 

--- a/community/sway/usr/share/sway/themes/catppuccin-macchiato/theme.conf
+++ b/community/sway/usr/share/sway/themes/catppuccin-macchiato/theme.conf
@@ -1,0 +1,50 @@
+# catppuccin-macchiato 
+
+# some global theme specific variables
+set $gtk-theme catppuccin-macchiato-blue-standard+default 
+set $icon-theme catppuccin-macchiato-blue-standard+default
+set $gui-font Roboto 11
+set $term-font JetBrainsMono NF
+set $gtk-color-scheme prefer-dark
+set $kvantum-theme catppuccin-macchiato-blue
+set $background $HOME/.config/sway/generated_background.svg
+
+set $rosewater #f4dbd6
+set $flamingo #f0c6c6
+set $pink #f5bde6
+set $mauve #c6a0f6
+set $red #ed8796
+set $maroon #ee99a0
+set $peach #f5a97f
+set $yellow #eed49f
+set $green #a6da95
+set $teal #8bd5ca
+set $sky #91d7e3
+set $sapphire #7dc4e4
+set $blue #8aadf4
+set $lavender #b7bdf8
+set $text #cad3f5
+set $subtext1 #b8c0e0
+set $subtext0 #a5adcb
+set $overlay2 #939ab7
+set $overlay1 #8087a2
+set $overlay0 #6e738d
+set $surface2 #5b6078
+set $surface1 #494d64
+set $surface0 #363a4f
+set $base #24273a
+set $mantle #1e2030
+set $crust #181926
+
+set $background-color $base
+set $text-color $text
+set $selection-color $color1
+set $accent-color $blue
+
+# target                 title     bg    text   indicator  border
+client.focused           $lavender $base $text  $rosewater $lavender
+client.focused_inactive  $overlay0 $base $text  $rosewater $overlay0
+client.unfocused         $overlay0 $base $text  $rosewater $overlay0
+client.urgent            $peach    $base $peach $overlay0  $peach
+client.placeholder       $overlay0 $base $text  $overlay0  $overlay0
+client.background        $base

--- a/community/sway/usr/share/sway/themes/catppuccin-mocha/foot-theme.ini
+++ b/community/sway/usr/share/sway/themes/catppuccin-mocha/foot-theme.ini
@@ -1,0 +1,40 @@
+include=/usr/share/sway/templates/foot.ini
+
+# ref.: https://github.com/catppuccin/foot/blob/962ff1a5b6387bc5419e9788a773a080eea5f1e1/themes/catppuccin-mocha.ini
+
+[cursor]
+color=11111b f5e0dc
+
+[colors]
+foreground=cdd6f4
+background=1e1e2e
+
+regular0=45475a
+regular1=f38ba8
+regular2=a6e3a1
+regular3=f9e2af
+regular4=89b4fa
+regular5=f5c2e7
+regular6=94e2d5
+regular7=bac2de
+
+bright0=585b70
+bright1=f38ba8
+bright2=a6e3a1
+bright3=f9e2af
+bright4=89b4fa
+bright5=f5c2e7
+bright6=94e2d5
+bright7=a6adc8
+
+16=fab387
+17=f5e0dc
+
+selection-foreground=cdd6f4
+selection-background=414356
+
+search-box-no-match=11111b f38ba8
+search-box-match=cdd6f4 313244
+
+jump-labels=11111b fab387
+urls=89b4fa

--- a/community/sway/usr/share/sway/themes/catppuccin-mocha/packages
+++ b/community/sway/usr/share/sway/themes/catppuccin-mocha/packages
@@ -1,0 +1,4 @@
+catppuccin-gtk-theme-mocha
+kvantum-theme-catppuccin-git
+ttf-jetbrains-mono-nerd
+ttf-roboto

--- a/community/sway/usr/share/sway/themes/catppuccin-mocha/theme.conf
+++ b/community/sway/usr/share/sway/themes/catppuccin-mocha/theme.conf
@@ -1,0 +1,50 @@
+# catppuccin-mocha 
+
+# some global theme specific variables
+set $gtk-theme catppuccin-mocha-blue-standard+default 
+set $icon-theme catppuccin-mocha-blue-standard+default
+set $gui-font Roboto 11
+set $term-font JetBrainsMono NF
+set $gtk-color-scheme prefer-dark
+set $kvantum-theme catppuccin-mocha-blue
+set $background $HOME/.config/sway/generated_background.svg
+
+set $rosewater #f5e0dc
+set $flamingo #f2cdcd
+set $pink #f5c2e7
+set $mauve #cba6f7
+set $red #f38ba8
+set $maroon #eba0ac
+set $peach #fab387
+set $yellow #f9e2af
+set $green #a6e3a1
+set $teal #94e2d5
+set $sky #89dceb
+set $sapphire #74c7ec
+set $blue #89b4fa
+set $lavender #b4befe
+set $text #cdd6f4
+set $subtext1 #bac2de
+set $subtext0 #a6adc8
+set $overlay2 #9399b2
+set $overlay1 #7f849c
+set $overlay0 #6c7086
+set $surface2 #585b70
+set $surface1 #45475a
+set $surface0 #313244
+set $base #1e1e2e
+set $mantle #181825
+set $crust #11111b
+
+set $background-color $base
+set $text-color $text
+set $selection-color $color1
+set $accent-color $blue
+
+# target                 title     bg    text   indicator  border
+client.focused           $lavender $base $text  $rosewater $lavender
+client.focused_inactive  $overlay0 $base $text  $rosewater $overlay0
+client.unfocused         $overlay0 $base $text  $rosewater $overlay0
+client.urgent            $peach    $base $peach $overlay0  $peach
+client.placeholder       $overlay0 $base $text  $overlay0  $overlay0
+client.background        $base

--- a/community/sway/usr/share/sway/themes/catppuccin-mocha/theme.conf
+++ b/community/sway/usr/share/sway/themes/catppuccin-mocha/theme.conf
@@ -1,4 +1,4 @@
-# catppuccin-mocha 
+# catppuccin-mocha
 
 # some global theme specific variables
 set $gtk-theme catppuccin-mocha-blue-standard+default 


### PR DESCRIPTION
resolves manjaro-sway/manjaro-sway#885

**Why?**

As I really like the catppuccin themes, because they provide consistent colors for dark and for light theme, I would love to add those to the existing theme switcher solution.

**How I tested it**

I currently enabled all those themes on my local machine by copying them into the `/usr/share/sway/themes` directory.