### PR TITLE
leverage systemctl sleep introduced in systemd 256

### DIFF
--- a/community/sway/etc/sway/idle.yaml
+++ b/community/sway/etc/sway/idle.yaml
@@ -23,10 +23,10 @@ timeouts:
     resume: swaymsg "output * dpms on"
   # sleep_timeout_bat
   - timeout: 900
-    command: acpi -b | grep Discharging && systemctl suspend
+    command: acpi -b | grep Discharging && systemctl sleep
   # sleep_timeout_ac
   - timeout: 3600
-    command: acpi -b | grep Discharging; test $? -eq 1 && systemctl suspend
+    command: acpi -b | grep Discharging; test $? -eq 1 && systemctl sleep
 before-sleep: swaymsg exec \$locking
 after-resume: swaymsg "output * dpms on"
 lock: swaymsg exec \$locking

--- a/community/sway/etc/sway/modes/shutdown
+++ b/community/sway/etc/sway/modes/shutdown
@@ -18,7 +18,7 @@ mode --pango_markup $mode_shutdown {
     $bindsym e exec $purge_cliphist; exec swaymsg exit
 
     # suspend
-    $bindsym u mode "default", exec systemctl suspend
+    $bindsym u mode "default", exec systemctl sleep
 
     # shutdown
     $bindsym s exec $purge_cliphist; exec systemctl poweroff


### PR DESCRIPTION
Use `systemctl sleep` to let systemd figure out the sleep mode automatically 