### PR TITLE
feat(swayidle): use --ac-adapter instead of -b

### DIFF
--- a/community/sway/etc/sway/idle.yaml
+++ b/community/sway/etc/sway/idle.yaml
@@ -23,10 +23,10 @@ timeouts:
     resume: swaymsg "output * dpms on"
   # sleep_timeout_bat
   - timeout: 900
-    command: acpi -b | grep Discharging && systemctl sleep
+    command: acpi --ac-adapter | grep -v 'on-line' && systemctl sleep
   # sleep_timeout_ac
   - timeout: 3600
-    command: acpi -b | grep Discharging; test $? -eq 1 && systemctl sleep
+    command: acpi --ac-adapter | grep 'online' && systemctl sleep
 before-sleep: swaymsg exec \$locking
 after-resume: swaymsg "output * dpms on"
 lock: swaymsg exec \$locking


### PR DESCRIPTION
Hello,

We use `acpi -b` to guess if the laptop is in connected to "the wall" (AC)
The issue is that `acpi` reports multiple chargeable device. On my home setup:

```shell
$ acpi -b
Battery 0: Discharging, 0%, rate information unavailable
Battery 1: Full, 100%
Battery 2: Discharging, 0%, rate information unavailable
```

Grepping on `Discharing` is wrong as 0 is my mouse, 1 is my laptop and 2 is my keyboard.

I propose with this change to use `acpi --ac-adapter` which returns

```shell
$ acpi --ac-adapter
Adapter 0: on-line
```

Grepping on `on-line` makes more sense to know if the laptop is connected. Other devices only report Charging and Discharging.

So
`acpi --ac-adapter | grep -v 'on-line'` for BAT mode
and
`acpi --ac-adapter | grep 'on-line'` for AC mode

