### PR TITLE
fix(theme-toggle): less cpu load using auto-switch

### DIFF
--- a/community/sway/usr/share/sway/scripts/theme-toggle.sh
+++ b/community/sway/usr/share/sway/scripts/theme-toggle.sh
@@ -64,8 +64,6 @@ ensure_theme() {
         /usr/bin/mv --backup -v "$HOME/.config/foot/foot-theme.$1.ini_" $PRIMARY_FOOT_THEME
 
         swaymsg reload
-    else
-        waybar-signal theme
     fi
 }
 
@@ -113,11 +111,12 @@ case $1'' in
         minutes=$((($next_switch_unix - $current_unix) / 60 % 60))
         text="switching to ${CURRENT_SECONDARY_THEME} theme in ${hours}h ${minutes}m\r(Right click to disable)"
         alt="auto_${CURRENT_PRIMARY_THEME}"
+
+        ensure_theme $NEXT_PRIMARY_THEME $NEXT_SECONDARY_THEME
     fi
 
     printf '{"alt":"%s","tooltip":"%s"}\n' "$alt" "$text"
 
-    ensure_theme $NEXT_PRIMARY_THEME $NEXT_SECONDARY_THEME
     exit 0
     ;;
 esac

--- a/community/sway/usr/share/sway/templates/waybar/config.jsonc
+++ b/community/sway/usr/share/sway/templates/waybar/config.jsonc
@@ -231,7 +231,7 @@
     },
     "custom/theme": {
         "format": "{icon}",
-        "interval": 60,
+        "interval": 300,
         "tooltip": true,
         "format-icons": {
             "light": "",


### PR DESCRIPTION
I was experiencing constant CPU load when using the auto-switch mode, even when I would have considered my machine idle. I did the following things to improve on that and now my system seams to really idle again:

1. only check if the theme must auto switch every 5 instead of every minute (minor, probably not the real impact)
2. only fire the `ensure_theme` method when it is really necessary (when the auto-mode is on)
3. if `ensure_theme` detects that the theme does not need to change, do not call `waybar-signal theme`