### PR TITLE
Update lock.sh to fix white background on lock-screen

### DIFF
--- a/community/sway/usr/share/sway/scripts/lock.sh
+++ b/community/sway/usr/share/sway/scripts/lock.sh
@@ -5,5 +5,5 @@ if [ -x "$(command -v gtklock)" ]; then
 elif [ -x "$(command -v waylock)" ]; then
     waylock -fork-on-lock
 elif [ -x "$(command -v swaylock)" ]; then
-    swaylock --daemonize --show-failed-attempts
+    swaylock --daemonize --show-failed-attempts --screenshots --clock --indicator --effect-blur 7x5 --effect-vignette 0.5:0.5 --fade-in 0.2
 fi

--- a/community/sway/usr/share/sway/scripts/lock.sh
+++ b/community/sway/usr/share/sway/scripts/lock.sh
@@ -4,6 +4,8 @@ if [ -x "$(command -v gtklock)" ]; then
     gtklock --daemonize --follow-focus --idle-hide --start-hidden
 elif [ -x "$(command -v waylock)" ]; then
     waylock -fork-on-lock
-elif [ -x "$(command -v swaylock)" ]; then
+elif pacman -Qs swaylock-effects >/dev/null; then
     swaylock --daemonize --show-failed-attempts --screenshots --clock --indicator --effect-blur 7x5 --effect-vignette 0.5:0.5 --fade-in 0.2
+elif pacman -Qs swaylock; then
+    swaylock --daemonize --show-failed-attempts
 fi


### PR DESCRIPTION
After a recent update, the lock screen displayed only a white background. I found that updating the lock screen using the listed options resolved the issue.