### PR TITLE
fix(sway): restore brightness after resume

### DIFF
--- a/community/sway/etc/sway/idle.yaml
+++ b/community/sway/etc/sway/idle.yaml
@@ -28,6 +28,6 @@ timeouts:
   - timeout: 3600
     command: acpi --ac-adapter | grep 'on-line' && systemctl sleep
 before-sleep: swaymsg exec \$locking
-after-resume: swaymsg "output * dpms on"
+after-resume: swaymsg "output * dpms on" && brightnessctl -r
 lock: swaymsg exec \$locking
 idlehint: '240'


### PR DESCRIPTION
Hi and thanks for all the amazing work on Manjaro Sway!

This MR fixes restoring device (e.g., laptop screen) brightness after resuming from sleep.