### PR TITLE
Add user flag to pkill commands

### DIFF
--- a/community/bspwm-minimal/skel/.config/bspwm/autostart
+++ b/community/bspwm-minimal/skel/.config/bspwm/autostart
@@ -55,6 +55,6 @@ srandrd atorandr.sh --change
 update-checker 7200 &
 xcape -e 'Super_L=Super_L|Shift_L|space' &
 dbus-launch gsettings set org.mate.NotificationDaemon theme 'slider' && sed -i '/gsettings/d' ~/.config/bspwm/autostart &
-mv ~/.config/sxhkd/sxhkdrc-minimal ~/.config/sxhkd/sxhkdrc && sleep 1 && pkill -USR1 -x sxhkd && sleep 1 && sed -i '/sxhkdrc-minimal/d' ~/.config/bspwm/autostart &
+mv ~/.config/sxhkd/sxhkdrc-minimal ~/.config/sxhkd/sxhkdrc && sleep 1 && pkill -U $USER -USR1 -x sxhkd && sleep 1 && sed -i '/sxhkdrc-minimal/d' ~/.config/bspwm/autostart &
 #lxpolkit &
 

--- a/community/i3/skel/.i3/config
+++ b/community/i3/skel/.i3/config
@@ -61,7 +61,7 @@ bindsym $mod+F3 exec pcmanfm
 # bindsym $mod+F3 exec ranger
 bindsym $mod+Shift+F3 exec pcmanfm_pkexec
 bindsym $mod+F5 exec terminal -e 'mocp'
-bindsym $mod+t exec --no-startup-id pkill picom
+bindsym $mod+t exec --no-startup-id pkill -U $USER picom
 bindsym $mod+Ctrl+t exec --no-startup-id picom -b
 bindsym $mod+Shift+d --release exec "killall dunst; exec notify-send 'restart dunst'"
 bindsym Print exec --no-startup-id i3-scrot

--- a/community/sway/etc/sway/autostart
+++ b/community/sway/etc/sway/autostart
@@ -2,7 +2,7 @@
 
 set $initialize_foot_server '[ -x "$(command -v foot)" ] && systemctl --now --user enable foot-server.socket && systemctl --now --user enable foot-server'
 set $initialize_swayr_daemon '[ -x "$(command -v swayrd)" ] && systemctl --now --user enable swayrd'
-set $initialize_waybar '[ -x "$(command -v waybar)" ] && (pkill waybar || exit 0) && systemctl --now --user enable waybar && (systemctl --user start waybar || /usr/share/sway/scripts/waybar.sh)'
+set $initialize_waybar '[ -x "$(command -v waybar)" ] && (pkill -U $USER waybar || exit 0) && systemctl --now --user enable waybar && (systemctl --user start waybar || /usr/share/sway/scripts/waybar.sh)'
 set $initialize_workspace_icons '[ -x "$(command -v sworkstyle)" ] && systemctl --now --user enable sworkstyle'
 set $initialize_poweralert_daemon '[ -x "$(command -v poweralertd)" ] && systemctl --now --user enable poweralertd'
 set $initialize_idlehack_daemon '[ -x "$(command -v idlehack)" ] && systemctl --now --user enable idlehack'
@@ -17,7 +17,7 @@ set $autostart_dex '[ -x "$(command -v dex)" ] && gdbus wait --session org.kde.S
 set $wlsunset '[ -x "$(command -v wlsunset)" ] && /usr/share/sway/scripts/sunset.sh "on"'
 set $autotiling '[ -x "$(command -v autotiling)" ] && autotiling || [ -x "$(command -v autotiling-rs)" ] && autotiling-rs'
 set $help_menu '[ -x "$(command -v nwg-wrapper)" ] && [ -f $HOME/.config/nwg-wrapper/help.sh ] && /usr/share/sway/scripts/help.sh'
-set $kanshi '[ -x "$(command -v kanshi)" ] && pkill -x kanshi; exec kanshi'
+set $kanshi '[ -x "$(command -v kanshi)" ] && pkill -U $USER -x kanshi; exec kanshi'
 set $xdg-dirs '[ -x "$(command -v xdg-user-dirs-update)" ] && exec xdg-user-dirs-update'
 
 ## apply the keyboard layout from localectl if no keyboard layout has been set via config.d
@@ -30,11 +30,11 @@ set $apply_background swaymsg 'output * bg $background fill'
 
 ## daemons
 
-set $mako '[ -x "$(command -v mako)" ] && pkill -x mako; /usr/share/sway/scripts/mako.sh --font "$term-font" --text-color "$text-color" --border-color "$accent-color" --background-color "$background-color" --border-size 3 --width 400 --height 200 --padding 20 --margin 20 --default-timeout 15000'
+set $mako '[ -x "$(command -v mako)" ] && pkill -U $USER -x mako; /usr/share/sway/scripts/mako.sh --font "$term-font" --text-color "$text-color" --border-color "$accent-color" --background-color "$background-color" --border-size 3 --width 400 --height 200 --padding 20 --margin 20 --default-timeout 15000'
 set $swappy_notify '[ -x "$(command -v swappy)" ] && /usr/share/sway/scripts/screenshot-notify.sh'
 set $cliphist_watch '[ -x "$(command -v wl-paste)" ] && [ -x "$(command -v cliphist)" ] && wl-paste --watch waybar-signal clipboard'
 set $cliphist_store '[ -x "$(command -v wl-paste)" ] && [ -x "$(command -v cliphist)" ] && wl-paste --watch cliphist store'
-set $clip-persist '[ -x "$(command -v wl-clip-persist)" ] && pkill -x wl-clip-persist; wl-clip-persist --clipboard regular --all-mime-type-regex \'(?i)^(?!image/x-inkscape-svg).+\''
+set $clip-persist '[ -x "$(command -v wl-clip-persist)" ] && pkill -U $USER -x wl-clip-persist; wl-clip-persist --clipboard regular --all-mime-type-regex \'(?i)^(?!image/x-inkscape-svg).+\''
 set $calendar_daemon 'calcurse --daemon'
-set $nm_applet '[ -x "$(command -v nm-applet)" ] && pkill -x nm-applet && dbus-launch nm-applet'
-set $watch_playerctl '[ -x "$(command -v playerctl)" ] && pkill -x playerctl; playerctl -a metadata --format \"{{status}} {{title}}\" --follow | while read line; do waybar-signal playerctl; waybar-signal idle; done'
+set $nm_applet '[ -x "$(command -v nm-applet)" ] && pkill -U $USER -x nm-applet && dbus-launch nm-applet'
+set $watch_playerctl '[ -x "$(command -v playerctl)" ] && pkill -U $USER -x playerctl; playerctl -a metadata --format \"{{status}} {{title}}\" --follow | while read line; do waybar-signal playerctl; waybar-signal idle; done'

--- a/community/sway/etc/sway/modes/default
+++ b/community/sway/etc/sway/modes/default
@@ -27,7 +27,7 @@ floating_modifier $mod normal
 $bindsym $mod+Shift+c reload
 
 ## Action // Toggle Waybar ##    
-$bindsym $mod+Shift+b exec pkill -x -SIGUSR1 waybar
+$bindsym $mod+Shift+b exec pkill -U $USER -x -SIGUSR1 waybar
 
 # --locked flags allow the buttons to be used whilst the screen is locked.
 $bindsym --locked XF86AudioRaiseVolume exec $volume_up

--- a/community/sway/usr/bin/inhibit-idle
+++ b/community/sway/usr/bin/inhibit-idle
@@ -20,7 +20,7 @@ case $1'' in
     inhibit $SECONDS
     ;;
 'off')
-    pkill -f "systemd-inhibit --what=idle" || true
+    pkill -U $USER -f "systemd-inhibit --what=idle" || true
     waybar-signal idle
     ;;
 esac

--- a/community/sway/usr/bin/waybar-signal
+++ b/community/sway/usr/bin/waybar-signal
@@ -31,4 +31,4 @@ if [ -z "$number" ]; then
     exit 1
 fi
 
-pkill -x -SIGRTMIN+${number} 'waybar'
+pkill -U $USER -x -SIGRTMIN+${number} 'waybar'

--- a/community/sway/usr/share/sway/scripts/help.sh
+++ b/community/sway/usr/share/sway/scripts/help.sh
@@ -13,11 +13,11 @@ if [ "$1" = "--toggle" ]; then
         touch "$LOCKFILE"
     fi
     # toggles the visibility
-    pkill -f -${VISIBILITY_SIGNAL} 'nwg-wrapper.*-s help.sh'
+    pkill -U $USER -f -${VISIBILITY_SIGNAL} 'nwg-wrapper.*-s help.sh'
 
 else
     # makes sure no "old" wrappers are mounted (on start and reload)
-    pkill -f -${QUIT_SIGNAL} 'nwg-wrapper.*-s help.sh'
+    pkill -U $USER -f -${QUIT_SIGNAL} 'nwg-wrapper.*-s help.sh'
     # mounts the wrapper to all outputs
     for output in $(swaymsg -t get_outputs --raw | jq -r '.[].name'); do
         # sets the initial visibility

--- a/community/sway/usr/share/sway/scripts/recorder.sh
+++ b/community/sway/usr/share/sway/scripts/recorder.sh
@@ -39,6 +39,6 @@ if [ $status != 0 ]; then
 
     waybar-signal recorder && notify "Finished recording ${file}"
 else
-    pkill -x --signal SIGINT wf-recorder
+    pkill -U $USER -x --signal SIGINT wf-recorder
     waybar-signal recorder
 fi

--- a/community/sway/usr/share/sway/scripts/sunset.sh
+++ b/community/sway/usr/share/sway/scripts/sunset.sh
@@ -34,7 +34,7 @@ start() {
 #Accepts managing parameter
 case $1'' in
 'off')
-    pkill -x wlsunset
+    pkill -U $USER -x wlsunset
     waybar-signal sunset
     ;;
 'on')
@@ -42,8 +42,8 @@ case $1'' in
     waybar-signal sunset
     ;;
 'toggle')
-    if pkill -x -0 wlsunset; then
-        pkill -x wlsunset
+    if pkill -U $USER -x -0 wlsunset; then
+        pkill -U $USER -x wlsunset
     else
         start
     fi
@@ -56,7 +56,7 @@ case $1'' in
 esac
 
 #Returns a string for Waybar
-if pkill -x -0 wlsunset; then
+if pkill -U $USER -x -0 wlsunset; then
     class="on"
     text="location-based gamma correction"
 else

--- a/community/sway/usr/share/sway/scripts/waybar.sh
+++ b/community/sway/usr/share/sway/scripts/waybar.sh
@@ -4,7 +4,7 @@
 USER_CONFIG_PATH=$HOME/.config/waybar/config.jsonc
 USER_STYLE_PATH=$HOME/.config/waybar/style.css
 
-pkill -x waybar
+pkill -U $USER -x waybar
 
 if [ -f "$USER_CONFIG_PATH" ]; then
     USER_CONFIG=$USER_CONFIG_PATH

--- a/community/sway/usr/share/sway/scripts/wob.sh
+++ b/community/sway/usr/share/sway/scripts/wob.sh
@@ -3,7 +3,7 @@
 #$1 - accent color. $2 - background color. $3 - new value
 # returns 0 (success) if $1 is running and is attached to this sway session; else 1
 is_running_on_this_screen() {
-    pkill -x -0 "wob" || return 1
+    pkill -U $USER -x -0 "wob" || return 1
     for pid in $(pgrep "wob"); do
         WOB_SWAYSOCK="$(tr '\0' '\n' </proc/"$pid"/environ | awk -F'=' '/^SWAYSOCK/ {print $2}')"
         if [ "$WOB_SWAYSOCK" = "$SWAYSOCK" ]; then
@@ -20,7 +20,7 @@ wob_pipe=~/.cache/$(basename "$SWAYSOCK").wob
 ini=~/.config/wob.ini
 
 refresh() {
-    pkill -x wob
+    pkill -U $USER -x wob
     rm $ini
     {
         echo "anchor = top center"


### PR DESCRIPTION
The pkill commands without user restriction attempt to kill other users' processes, leading to slow desktop performance in some situations. I had to install it on a new computer and was trying to figure out why it was slow, and this is a modification I had done in the past. 

Switch to a different tty and run `systemctl start --user sway` and you'll find several error messages about pkill, particularly around the waybar.  

Added `-U $USER` flag to all pkill commands to restrict killing to the current user space based on the environment. 