### PR TITLE
fix(foot): deprecated config option

### DIFF
--- a/community/sway/usr/share/sway/templates/foot.ini
+++ b/community/sway/usr/share/sway/templates/foot.ini
@@ -50,7 +50,6 @@ lines=10000
 
 [cursor]
 # style=block
-color=141a1b eeeeee
 # blink=no
 # beam-thickness=1.5
 # underline-thickness=<font underline thickness>
@@ -131,6 +130,7 @@ color=141a1b eeeeee
 alpha=0.9
 foreground=eeeeee
 background=141a1b
+cursor=141a1b eeeeee
 regular0=141a1B  # black
 regular1=cd3f45  # red
 regular2=9fca56  # green


### PR DESCRIPTION
From the [foot changelog entry for release 1.23](https://codeberg.org/dnkl/foot/src/branch/master/CHANGELOG.md#1-23-0):

> `cursor.color` moved to `colors.cursor`