### PR TITLE
refactor(scripts): imports and style

### DIFF
--- a/community/sway/usr/share/sway/scripts/first-empty-workspace.py
+++ b/community/sway/usr/share/sway/scripts/first-empty-workspace.py
@@ -2,7 +2,6 @@
 
 import i3ipc
 from argparse import ArgumentParser
-from time import sleep
 
 # Assumption: it exists 10 workspaces (otherwise, change this value)
 NUM_WORKSPACES = 10
@@ -31,7 +30,8 @@ if __name__ == "__main__":
     workspace_numbers = [workspace.num for workspace in workspaces]
     empty_workspace_numbers = set([number for number in range(1,NUM_WORKSPACES+1)]) - set(workspace_numbers)
     # Take into consideration that the current workspace exists but might be empty
-    if len(current_workspace.nodes) == 0: empty_workspace_numbers.add(current_workspace.num)
+    if len(current_workspace.nodes) == 0:
+        empty_workspace_numbers.add(current_workspace.num)
 
     # Get the minor empty workspace's number (or set it as the current workspace's number if all are busy)
     first_empty_workspace_number = current_workspace.num

--- a/community/sway/usr/share/sway/scripts/sbdp.py
+++ b/community/sway/usr/share/sway/scripts/sbdp.py
@@ -58,7 +58,7 @@ def getDocsConfig(lines: list[str]):
             config.category = match.group('category')
             config.action = match.group('action')
             config.keybinding = match.group('keybinding')
-            if (config.keybinding == None):
+            if (config.keybinding is None):
                 config.keybinding = findKeybindingForLine(index, lines)
             docsConfig = docsConfig + [config]
     return docsConfig

--- a/community/sway/usr/share/sway/scripts/valent.py
+++ b/community/sway/usr/share/sway/scripts/valent.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 import dbus
 import json
-import logging, sys
+import logging
+import sys
 import os
 import math
 

--- a/community/sway/usr/share/sway/scripts/weather.py
+++ b/community/sway/usr/share/sway/scripts/weather.py
@@ -6,7 +6,6 @@ import json
 import locale
 import sys
 import urllib.parse
-from datetime import datetime
 import requests
 import configparser
 from os import path, environ


### PR DESCRIPTION
Minor cleanup of python scripts: removed unused imports and improved linting
- [E711](https://docs.astral.sh/ruff/rules/none-comparison/)
- [E701](https://docs.astral.sh/ruff/rules/multiple-statements-on-one-line-colon/)