### PR TITLE
Remove shell debugging flag

### DIFF
--- a/community/sway/usr/share/sway/scripts/enable-gtk-theme.sh
+++ b/community/sway/usr/share/sway/scripts/enable-gtk-theme.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -xu
+set -u
 
 THEME=$1
 

--- a/community/sway/usr/share/sway/scripts/fontconfig.sh
+++ b/community/sway/usr/share/sway/scripts/fontconfig.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-set -xu
+set -u
 
 export CATEGORY=${1:-"monospace"}
 export FONT=${2:-"JetBrainsMono NF"}
@@ -8,4 +8,4 @@ FONTCONFIG_DIR=$HOME/.config/fontconfig/conf.d
 
 mkdir -p $FONTCONFIG_DIR
 
-cat /usr/share/sway/templates/fontconfig.conf | envsubst > $FONTCONFIG_DIR/51-${CATEGORY}.conf
+cat /usr/share/sway/templates/fontconfig.conf | envsubst >$FONTCONFIG_DIR/51-${CATEGORY}.conf

--- a/community/sway/usr/share/sway/scripts/generate-bg.sh
+++ b/community/sway/usr/share/sway/scripts/generate-bg.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env sh
-set -xu
+set -u
 
 export CROWN=$1
 export ROOT=$2
 export BACKGROUND=$3
 
 # shellcheck disable=SC2002
-cat /usr/share/sway/templates/manjarosway-scalable.svg | envsubst > "$HOME/.config/sway/generated_background.svg"
+cat /usr/share/sway/templates/manjarosway-scalable.svg | envsubst >"$HOME/.config/sway/generated_background.svg"

--- a/community/sway/usr/share/sway/scripts/help.sh
+++ b/community/sway/usr/share/sway/scripts/help.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env sh
-set -x
 # toggles the help wrapper state
 
 VISIBILITY_SIGNAL=30

--- a/community/sway/usr/share/sway/scripts/keyboard-backlight-switch.sh
+++ b/community/sway/usr/share/sway/scripts/keyboard-backlight-switch.sh
@@ -1,15 +1,14 @@
 #!/usr/bin/env sh
-set -x
 
 case $1'' in
-'on')
-    for device in $DEVICES; do
-        brightnessctl -r -d "*kbd_backlight"
-    done
-    ;;
-'off')
-    for device in $DEVICES; do
-        brightnessctl -s -d "*kbd_backlight" && brightnessctl -d "*kbd_backlight" set 0
-    done
-    ;;
+    'on')
+        for device in $DEVICES; do
+            brightnessctl -r -d "*kbd_backlight"
+        done
+        ;;
+    'off')
+        for device in $DEVICES; do
+            brightnessctl -s -d "*kbd_backlight" && brightnessctl -d "*kbd_backlight" set 0
+        done
+        ;;
 esac

--- a/community/sway/usr/share/sway/scripts/recorder.sh
+++ b/community/sway/usr/share/sway/scripts/recorder.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env sh
-set -x
-
 pgrep wf-recorder
 status=$?
 

--- a/community/sway/usr/share/sway/scripts/screenshot-notify.sh
+++ b/community/sway/usr/share/sway/scripts/screenshot-notify.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
-
 set -e
+
 DIR=${XDG_SCREENSHOTS_DIR:-$HOME/Screenshots}
 
 while true; do

--- a/community/sway/usr/share/sway/scripts/type-to-app.sh
+++ b/community/sway/usr/share/sway/scripts/type-to-app.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -x
 
 PID=$(swaymsg -t get_tree | jq '.. | select(.type?) | select(.focused==true) | .pid')
 
@@ -8,8 +7,7 @@ shift
 type=$@
 
 swaymsg [$matcher] focus
-    if [ "$?" = "0" ]
-then
+if [ "$?" = "0" ]; then
     wtype $type
     swaymsg "[pid=$PID] focus"
 fi


### PR DESCRIPTION
The -x flag is usually used for debugging. It creates a lot of noise in journalctl. This PR removes it.

Overall `set -euo pipefail` might be desirable, but this would need a more testing.