### PR TITLE
Fixing single quote escaping in the autostart file.

### DIFF
--- a/community/sway/etc/sway/autostart
+++ b/community/sway/etc/sway/autostart
@@ -34,7 +34,7 @@ set $mako '[ -x "$(command -v mako)" ] && pkill -U $USER -x mako; /usr/share/swa
 set $swappy_notify '[ -x "$(command -v swappy)" ] && /usr/share/sway/scripts/screenshot-notify.sh'
 set $cliphist_watch '[ -x "$(command -v wl-paste)" ] && [ -x "$(command -v cliphist)" ] && wl-paste --watch waybar-signal clipboard'
 set $cliphist_store '[ -x "$(command -v wl-paste)" ] && [ -x "$(command -v cliphist)" ] && wl-paste --watch cliphist store'
-set $clip-persist '[ -x "$(command -v wl-clip-persist)" ] && pkill -U $USER -x wl-clip-persist; wl-clip-persist --clipboard regular --all-mime-type-regex \'(?i)^(?!image/x-inkscape-svg).+\''
+set $clip-persist  '[ -x "$(command -v wl-clip-persist)" ] && pkill -U $USER -x wl-clip-persist; wl-clip-persist --clipboard regular --all-mime-type-regex '"'"'(?i)^(?!image/x-inkscape-svg).+'"'"
 set $calendar_daemon 'calcurse --daemon'
 set $nm_applet '[ -x "$(command -v nm-applet)" ] && pkill -U $USER -x nm-applet && dbus-launch nm-applet'
 set $watch_playerctl '[ -x "$(command -v playerctl)" ] && pkill -U $USER -x playerctl; playerctl -a metadata --format \"{{status}} {{title}}\" --follow | while read line; do waybar-signal playerctl; waybar-signal idle; done'


### PR DESCRIPTION
When sway starts, I see the following errors in journalctl:
```
dec DD HH:MM:SS HOSTNAME sway[55903]: sh: -c: line 1: syntax error near unexpected token `('
dec DD HH:MM:SS HOSTNAME sway[55903]: sh: -c: line 1: `[ -x "$(command -v wl-clip-persist)" ] && pkill -U $USER -x wl-clip-persist; wl-clip-persist --clipboard regular --all-mime-type-regex (?i)^(?!image/x-inkscape-svg).+'
```

I found that the source has a quoting error in the autostart file when setting the `clip-persist` variable.
I just escaped it. I did it by closing the single quote, opening a double quote, inserting the quoted single quote, and closing the double quote.