### PR TITLE
fix breeze cursor theme name

### DIFF
--- a/community/sway/usr/share/sway/themes/matcha-blue/packages
+++ b/community/sway/usr/share/sway/themes/matcha-blue/packages
@@ -1,5 +1,5 @@
 papirus-icon-theme
-xcursor-breeze
+breeze-cursors5
 matcha-gtk-theme
 kvantum-theme-matcha
 ttf-roboto

--- a/community/sway/usr/share/sway/themes/matcha-blue/theme.conf
+++ b/community/sway/usr/share/sway/themes/matcha-blue/theme.conf
@@ -4,7 +4,7 @@
 # some global theme specific variables
 set $gtk-theme Matcha-dark-azul
 set $icon-theme Papirus-Dark
-set $cursor-theme xcursor-breeze
+set $cursor-theme breeze-cursors5
 set $gui-font Roboto 11
 set $term-font JetBrainsMono NF
 set $gtk-color-scheme prefer-dark

--- a/community/sway/usr/share/sway/themes/matcha-green/packages
+++ b/community/sway/usr/share/sway/themes/matcha-green/packages
@@ -1,5 +1,5 @@
 papirus-maia-icon-theme
-xcursor-breeze
+breeze-cursors5
 matcha-gtk-theme
 kvantum-theme-matcha
 ttf-roboto

--- a/community/sway/usr/share/sway/themes/matcha-green/theme.conf
+++ b/community/sway/usr/share/sway/themes/matcha-green/theme.conf
@@ -4,7 +4,7 @@
 # some global theme specific variables
 set $gtk-theme Matcha-dark-sea
 set $icon-theme Papirus-Dark-Maia
-set $cursor-theme xcursor-breeze
+set $cursor-theme breeze-cursors5
 set $gui-font Roboto 11
 set $term-font JetBrainsMono NF
 set $gtk-color-scheme prefer-dark

--- a/community/sway/usr/share/sway/themes/matcha-leaf/packages
+++ b/community/sway/usr/share/sway/themes/matcha-leaf/packages
@@ -1,5 +1,5 @@
 papirus-maia-icon-theme
-xcursor-breeze
+breeze-cursors5
 matcha-gtk-theme
 kvantum-theme-matcha
 ttf-roboto

--- a/community/sway/usr/share/sway/themes/matcha-leaf/theme.conf
+++ b/community/sway/usr/share/sway/themes/matcha-leaf/theme.conf
@@ -4,7 +4,7 @@
 # some global theme specific variables
 set $gtk-theme Matcha-dark-pueril
 set $icon-theme Papirus-Dark-Maia
-set $cursor-theme xcursor-breeze
+set $cursor-theme breeze-cursors5
 set $gui-font Roboto 11
 set $term-font JetBrainsMono NF
 set $gtk-color-scheme prefer-dark

--- a/community/sway/usr/share/sway/themes/matcha-red/packages
+++ b/community/sway/usr/share/sway/themes/matcha-red/packages
@@ -1,5 +1,5 @@
 papirus-maia-icon-theme
-xcursor-breeze
+breeze-cursors5
 matcha-gtk-theme
 kvantum-theme-matcha
 ttf-roboto

--- a/community/sway/usr/share/sway/themes/matcha-red/theme.conf
+++ b/community/sway/usr/share/sway/themes/matcha-red/theme.conf
@@ -4,7 +4,7 @@
 # some global theme specific variables
 set $gtk-theme Matcha-dark-aliz
 set $icon-theme Papirus-Dark-Maia
-set $cursor-theme xcursor-breeze
+set $cursor-theme breeze-cursors5
 set $gui-font Roboto 11
 set $term-font JetBrainsMono NF
 set $gtk-color-scheme prefer-dark


### PR DESCRIPTION
Fix cursor issues stemming from renamed package on Manjaro `unstable` branch (`xcursor-breeze` replaced by `breeze-cursors5`).  For example, from `waybar` logs:

```
waybar[12967]: Unable to load hand2 from the cursor theme
waybar[12967]: Unable to load arrow from the cursor theme
```

After updating to `breeze-cursors5`, the `cursors` directories existing on my system were:

```console
$ find /usr/share/icons -type d -name "cursors"
/usr/share/icons/breeze-cursors5-snow/cursors
/usr/share/icons/Adwaita/cursors
/usr/share/icons/breeze-cursors5/cursors
```

<details><summary>Expand for <code>breeze-cursors5</code> package info</summary>
<p>

```console
$ pacman -Sii breeze-cursors5

Repository      : extra
Name            : breeze-cursors5
Version         : 5.27.12-1
Description     : KDE Plasma 5 Breeze & Breeze Snow cursor theme
Architecture    : any
URL             : https://kde.org/plasma-desktop
Licenses        : LGPL-2.0-or-later
Groups          : None
Provides        : None
Depends On      : None
Optional Deps   : None
Required By     : manjaro-i3-settings  manjaro-sway-settings  manjaro-sway-settings-git
                  manjaro-xfce-minimal-settings  manjaro-xfce-settings
Optional For    : None
Conflicts With  : xcursor-breeze
Replaces        : xcursor-breeze
Download Size   : 470.43 KiB
Installed Size  : 5305.92 KiB
Packager        : Mark Wagie <mark@manjaro.org>
Build Date      : Tue 17 Feb 2026 10:32:19 AM MST
MD5 Sum         : b49fdfda4b6d2e54f6aab2d4fc5cc3af
SHA-256 Sum     : 664f27629bee939f4435d83ce08f8a886203283132ee45835ddb8609b3b1aa6f
Signatures      : 150C200743ED46D8
Extended Data   : None
```

```console
$ pacman -Ql breeze-cursors5

breeze-cursors5 /usr/
breeze-cursors5 /usr/share/
breeze-cursors5 /usr/share/icons/
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/00000000000000020006000e7e9ffc3f
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/00008160000006810000408080010102
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/03b6e0fcb3499374a867c041f52298f0
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/08e8e1c95fe2fc01f976f1e063a24ccd
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/1081e37283d90000800003c07f3ef6bf
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/3085a0e285430894940527032f8b26df
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/3ecb610c1bf2410f44200f48c40d3599
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/4498f0e0c1937ffe01fd06f973665830
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/5c6cd98b3f3ebcb1f9c7f1c204630408
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/6407b0e94181790501fd1e167b474872
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/640fb0e74195791501fd1ed57b41487f
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/9081237383d90e509aa00f00170e968f
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/9d800788f1b08800ae810202380a0822
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/a2a266d0498c3104214a47bd64ab0fc8
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/alias
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/all-scroll
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/arrow
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/b66166c04f8c3109214a4fbd64a50fc8
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/bottom_left_corner
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/bottom_right_corner
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/bottom_side
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/cell
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/center_ptr
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/circle
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/closedhand
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/col-resize
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/color-picker
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/context-menu
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/copy
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/cross
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/crossed_circle
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/crosshair
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/d9ce0ab605698f320427677b458ad60b
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/default
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/dnd-copy
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/dnd-move
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/dnd-no-drop
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/dnd-none
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/down-arrow
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/draft
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/e-resize
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/e29285e634086352946a0e7090d73106
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/ew-resize
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/fcf21c00b30f7e3f83fe0dfd12e71cff
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/fleur
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/forbidden
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/grab
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/grabbing
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/h_double_arrow
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/half-busy
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/hand1
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/hand2
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/help
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/ibeam
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/left-arrow
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/left_ptr
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/left_ptr_help
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/left_ptr_watch
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/left_side
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/link
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/move
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/n-resize
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/ne-resize
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/nesw-resize
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/no-drop
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/not-allowed
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/ns-resize
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/nw-resize
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/nwse-resize
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/openhand
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/pencil
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/pirate
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/plus
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/pointer
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/pointing_hand
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/progress
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/question_arrow
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/right-arrow
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/right_ptr
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/right_side
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/row-resize
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/s-resize
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/sb_h_double_arrow
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/sb_v_double_arrow
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/se-resize
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/size-bdiag
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/size-fdiag
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/size-hor
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/size-ver
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/size_all
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/size_bdiag
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/size_fdiag
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/size_hor
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/size_ver
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/split_h
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/split_v
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/sw-resize
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/tcross
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/text
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/thumbnail.png
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/top_left_arrow
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/top_left_corner
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/top_right_corner
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/top_side
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/up-arrow
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/v_double_arrow
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/vertical-text
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/w-resize
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/wait
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/watch
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/wayland-cursor
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/whats_this
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/x-cursor
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/xterm
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/zoom-in
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/cursors/zoom-out
breeze-cursors5 /usr/share/icons/breeze-cursors5-snow/index.theme
breeze-cursors5 /usr/share/icons/breeze-cursors5/
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/00000000000000020006000e7e9ffc3f
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/00008160000006810000408080010102
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/03b6e0fcb3499374a867c041f52298f0
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/08e8e1c95fe2fc01f976f1e063a24ccd
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/1081e37283d90000800003c07f3ef6bf
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/3085a0e285430894940527032f8b26df
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/3ecb610c1bf2410f44200f48c40d3599
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/4498f0e0c1937ffe01fd06f973665830
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/5c6cd98b3f3ebcb1f9c7f1c204630408
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/6407b0e94181790501fd1e167b474872
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/640fb0e74195791501fd1ed57b41487f
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/9081237383d90e509aa00f00170e968f
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/9d800788f1b08800ae810202380a0822
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/a2a266d0498c3104214a47bd64ab0fc8
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/alias
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/all-scroll
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/arrow
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/b66166c04f8c3109214a4fbd64a50fc8
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/bottom_left_corner
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/bottom_right_corner
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/bottom_side
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/cell
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/center_ptr
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/circle
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/closedhand
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/col-resize
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/color-picker
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/context-menu
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/copy
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/cross
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/crossed_circle
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/crosshair
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/d9ce0ab605698f320427677b458ad60b
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/default
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/dnd-copy
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/dnd-move
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/dnd-no-drop
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/dnd-none
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/down-arrow
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/draft
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/e-resize
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/e29285e634086352946a0e7090d73106
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/ew-resize
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/fcf21c00b30f7e3f83fe0dfd12e71cff
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/fleur
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/forbidden
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/grab
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/grabbing
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/h_double_arrow
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/half-busy
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/hand1
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/hand2
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/help
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/ibeam
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/left-arrow
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/left_ptr
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/left_ptr_help
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/left_ptr_watch
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/left_side
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/link
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/move
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/n-resize
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/ne-resize
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/nesw-resize
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/no-drop
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/not-allowed
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/ns-resize
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/nw-resize
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/nwse-resize
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/openhand
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/pencil
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/pirate
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/plus
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/pointer
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/pointing_hand
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/progress
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/question_arrow
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/right-arrow
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/right_ptr
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/right_side
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/row-resize
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/s-resize
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/sb_h_double_arrow
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/sb_v_double_arrow
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/se-resize
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/size-bdiag
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/size-fdiag
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/size-hor
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/size-ver
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/size_all
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/size_bdiag
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/size_fdiag
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/size_hor
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/size_ver
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/split_h
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/split_v
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/sw-resize
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/tcross
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/text
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/thumbnail.png
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/top_left_arrow
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/top_left_corner
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/top_right_corner
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/top_side
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/up-arrow
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/v_double_arrow
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/vertical-text
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/w-resize
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/wait
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/watch
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/wayland-cursor
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/whats_this
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/x-cursor
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/xterm
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/zoom-in
breeze-cursors5 /usr/share/icons/breeze-cursors5/cursors/zoom-out
breeze-cursors5 /usr/share/icons/breeze-cursors5/index.theme

```

</p>
</details> 


## Changes

- **fix(sway): Update cursor-theme (match renamed pkg breeze-cursors5)**
- **fix(bspwm): Update cursor-theme (match renamed pkg breeze-cursors5)**
- **fix(mate): Update cursor-theme (match renamed pkg breeze-cursors5)**
- **fix(budgie): Update cursor-theme (match renamed pkg breeze-cursors5)**
- **fix(webdad/jade): Update cursor-theme (match renamed pkg breeze-cursors5)**

### Notes

It looks like there is also mention of the old name (`xcursor-breeze`) in the `default-cursors` package from upstream Arch Linux:

<details><summary>Expand for <code>default-cursors</code> package details</summary>
<p>

```console
$ pacman -Qii default-cursors
Name            : default-cursors
Version         : 3-1
Description     : Default cursor set
Architecture    : any
URL             : https://archlinux.org
Licenses        : CC0-1.0
Groups          : None
Provides        : None
Depends On      : None
Optional Deps   : adwaita-cursors: default cursor theme [installed]
Required By     : libxcursor  wayland
Optional For    : None
Conflicts With  : None
Replaces        : None
Installed Size  : 30.00 B
Packager        : Jan Alexander Steffens (heftig) <heftig@archlinux.org>
Build Date      : Fri 20 Sep 2024 04:10:39 PM MDT
Install Date    : Thu 10 Oct 2024 03:11:18 AM MDT
Install Reason  : Installed as a dependency for another package
Install Script  : No
Validated By    : Signature
Backup Files    : /usr/share/icons/default/index.theme [modified]
Extended Data   : pkgtype=pkg


```

```console
$ pacman -Ql default-cursors
default-cursors /usr/
default-cursors /usr/share/
default-cursors /usr/share/icons/
default-cursors /usr/share/icons/default/
default-cursors /usr/share/icons/default/index.theme

```

`/usr/share/icons/default/index.theme`:

```console
[Icon Theme]
Inherits=xcursor-breeze

```

</p>
</details>

This will likely need to change to match the new cursor theme name, or we must override it with `~/.icons/default/index.theme` like so:

```ini
[Icon Theme]
Inherits=breeze-cursors5
```