### PR TITLE
feat(theme): make 90-enable-theme.conf modular via variables

### DIFF
--- a/community/sway/etc/sway/config.d/90-enable-theme.conf
+++ b/community/sway/etc/sway/config.d/90-enable-theme.conf
@@ -1,17 +1,16 @@
 exec_always {
-  /usr/share/sway/scripts/enable-gtk-theme.sh "$gtk-theme"
-  gsettings set org.gnome.desktop.interface icon-theme "$icon-theme"
-  gsettings set org.gnome.desktop.interface color-scheme "$gtk-color-scheme"
-  /usr/share/sway/scripts/enable-cursor-theme.sh "$cursor-theme"
-  gsettings set org.gnome.desktop.interface font-name "$gui-font"
-  gsettings set org.gnome.desktop.input-sources show-all-sources true
-  gsettings set org.gnome.desktop.interface monospace-font-name "$term-font"
-  /usr/share/sway/scripts/fontconfig.sh "monospace" "$term-font"
-  /usr/share/sway/scripts/update-vscode-settings.sh "$term-font" "$vscode-theme"
-  /usr/share/sway/scripts/update-zed-settings.sh "$term-font" "$vscode-theme"
-  /usr/share/sway/scripts/generate-bg.sh "$accent-color" "$text-color" "$background-color"
-  /usr/share/sway/scripts/generate-waybar-style.sh "$background-color" "$text-color" "$accent-color" "$color8" "$color9"
+  $apply_gtk_theme
+  $apply_icon_theme
+  $apply_color_scheme
+  $apply_cursor_theme
+  $apply_gui_font
+  $configure_input_sources
+  $apply_monospace_font
+  $configure_fontconfig
+  $apply_vscode_settings
+  $apply_zed_settings
+  $generate_background
+  $generate_waybar_style
 
-  kvantummanager --set "$kvantum-theme"
+  $apply_kvantum_theme
 }
-

--- a/community/sway/etc/sway/definitions
+++ b/community/sway/etc/sway/definitions
@@ -29,6 +29,21 @@ set $unbindsym unbindsym --to-code
 # Script paths
 set $script_path /usr/share/sway/scripts
 
+# Theme application (override any variable with "" to disable)
+set $apply_gtk_theme $script_path/enable-gtk-theme.sh "$gtk-theme"
+set $apply_icon_theme gsettings set org.gnome.desktop.interface icon-theme "$icon-theme"
+set $apply_color_scheme gsettings set org.gnome.desktop.interface color-scheme "$gtk-color-scheme"
+set $apply_cursor_theme $script_path/enable-cursor-theme.sh "$cursor-theme"
+set $apply_gui_font gsettings set org.gnome.desktop.interface font-name "$gui-font"
+set $configure_input_sources gsettings set org.gnome.desktop.input-sources show-all-sources true
+set $apply_monospace_font gsettings set org.gnome.desktop.interface monospace-font-name "$term-font"
+set $configure_fontconfig $script_path/fontconfig.sh "monospace" "$term-font"
+set $apply_vscode_settings $script_path/update-vscode-settings.sh "$term-font" "$vscode-theme"
+set $apply_zed_settings $script_path/update-zed-settings.sh "$term-font" "$vscode-theme"
+set $generate_background $script_path/generate-bg.sh "$accent-color" "$text-color" "$background-color"
+set $generate_waybar_style $script_path/generate-waybar-style.sh "$background-color" "$text-color" "$accent-color" "$color8" "$color9"
+set $apply_kvantum_theme kvantummanager --set "$kvantum-theme"
+
 # Terminal emulator
 set $term footclient
 set $term_cwd $term -D "$(swaycwd 2>/dev/null || echo $HOME)"


### PR DESCRIPTION
Extract each exec_always line in `90-enable-theme.conf` into a named variable in definitions. 

Users can now override any variable with `""` in `definitions.d/*.conf` to disable individual theme scripts on reload, without touching upstream config files.

Motivation: I'm using a customized waybar layout (including custom blocks and styles). The recent introduction of `generate-waybar-style.sh` "broke" that.

I think that having that modular approach keeps most users at the status quo of using the Manjaro Sway defaults, but allows others to opt out of different aspects (e.g. `skip-generate-bg.sh` if a custom background is used).