### PR TITLE
Fix geoip.sh when curl fails (e.g. no internet connection)

### DIFF
--- a/community/sway/usr/share/sway/scripts/geoip.sh
+++ b/community/sway/usr/share/sway/scripts/geoip.sh
@@ -2,10 +2,15 @@
 set -u
 
 cache_file="$HOME/.cache/geoip"
-cache_time=$(date -r "$cache_file" +%s)
+cache_time=$(date -r "$cache_file" +%s 2>/dev/null || echo 0)
 yesterday_time=$(date -d 'now - 6 hour' +%s)
 start_of_day=$(date -d '00:00' +%s)
-if [ ! -f "$cache_file" ] || [ $cache_time -lt $yesterday_time ] || [ $cache_time -lt $start_of_day ]; then
-    curl -sL https://manjaro-sway.download/geoip >"$cache_file"
+if [ ! -f "$cache_file" ] || [ "$cache_time" -lt "$yesterday_time" ] || [ "$cache_time" -lt "$start_of_day" ]; then
+	tmp_file=$(mktemp "${cache_file}.tmp.XXXXXX") || exit 1
+	if curl -fsSL "https://manjaro-sway.download/geoip" > "$tmp_file" && [ -s "$tmp_file" ]; then
+		mv "$tmp_file" "$cache_file"
+	else
+		rm -f "$tmp_file"
+	fi
 fi
 cat "$cache_file"


### PR DESCRIPTION
In geoip.sh, when the curl command fails, it clears the cache file. We are no longer able to use the existing cache. Plus, we don't try to update the invalid cache file for the next 6 hours.

Instead, we should keep the existing cache file and use its coordinates.

This is a common issue while travelling with a laptop as it's common to be somewhere without a known network at sway startup.

---

Add-on: an argument can be made that after some amount of time without internet access, we should delete the cache file, which would then make us use the fallback coordinates once again. This can be dealt with in a separate PR as this PR is meant to fix unintended behaviour of the existing code.