### PR TITLE
fix(wob): stop overwriting user wob.ini on every reload

### DIFF
--- a/community/sway/usr/share/sway/scripts/wob.sh
+++ b/community/sway/usr/share/sway/scripts/wob.sh
@@ -1,7 +1,16 @@
 #!/usr/bin/env sh
-# https://github.com/francma/wob/wiki/wob-wrapper-script
-#$1 - accent color. $2 - background color. $3 - new value
-# returns 0 (success) if $1 is running and is attached to this sway session; else 1
+# wrapper script for wob — https://github.com/francma/wob/wiki/wob-wrapper-script
+# $1 - accent color   $2 - background color   $3 - new value | --refresh
+#
+# Theme colors are kept in a managed file that is regenerated on every theme
+# switch; the user's ~/.config/wob.ini is seeded once and then never touched.
+# The config handed to wob is the managed colors followed by the user file, so
+# anything set in ~/.config/wob.ini overrides the theme (same model as waybar's
+# colors.css/style.css split).
+
+MARKER="# managed by manjaro-sway"
+
+# returns 0 (success) if wob is running and is attached to this sway session; else 1
 is_running_on_this_screen() {
     pkill -U $USER -x -0 "wob" || return 1
     for pid in $(pgrep "wob"); do
@@ -17,33 +26,61 @@ wob_pipe=~/.cache/$(basename "$SWAYSOCK").wob
 
 [ -p "$wob_pipe" ] || mkfifo "$wob_pipe"
 
-ini=~/.config/wob.ini
+user_ini=~/.config/wob.ini
+colors_ini=~/.config/wob.colors.ini
+effective_ini=~/.cache/$(basename "$SWAYSOCK").wob.ini
 
 to_wob_color() {
-    # wob expects RRGGBBAA; sway themes provide #RRGGBB
-    local hex="${1#\#}"
+    # wob expects RRGGBB[AA]; sway themes provide #RRGGBB
+    hex="${1#\#}"
     echo "${hex}FF"
 }
 
-refresh() {
-    pkill -U $USER -x wob
-    rm -f $ini
+# Theme-managed colors only — safe to overwrite on every theme switch.
+refresh_colors() {
     {
-        echo "anchor = top center"
-        echo "margin = 20"
+        echo "$MARKER — regenerated on every theme switch, edits here are lost."
+        echo "# Put overrides in ~/.config/wob.ini instead."
         echo "border_color = $(to_wob_color "$1")"
         echo "bar_color = $(to_wob_color "$1")"
         echo "background_color = $(to_wob_color "$2")"
-    } >>$ini
+    } >"$colors_ini"
 }
 
-if [ ! -f "$ini" ] || [ "$3" = "--refresh" ]; then
-   refresh "$1" "$2"
+# Seed the user config once, then leave it alone.
+seed_user_ini() {
+    # Migrate the legacy auto-generated wob.ini (no marker, baked-in colors) out
+    # of the way so its hard-coded colors stop shadowing the managed theme.
+    if [ -f "$user_ini" ] && ! grep -qF "$MARKER" "$user_ini" && grep -qF "bar_color" "$user_ini"; then
+        mv "$user_ini" "$user_ini.bak"
+    fi
+    [ -f "$user_ini" ] && return
+    {
+        echo "$MARKER seeded this file once; it is now yours to edit freely."
+        echo "# Colors come from ~/.config/wob.colors.ini (theme-managed);"
+        echo "# anything set here overrides the theme."
+        echo "anchor = top center"
+        echo "margin = 20"
+    } >"$user_ini"
+}
+
+# Managed colors first so user settings in wob.ini take precedence.
+build_effective_ini() {
+    cat "$colors_ini" "$user_ini" >"$effective_ini"
+}
+
+seed_user_ini
+if [ ! -f "$colors_ini" ] || [ "$3" = "--refresh" ]; then
+    refresh_colors "$1" "$2"
 fi
+build_effective_ini
+
+# On a theme refresh, restart wob so the new colors take effect.
+[ "$3" = "--refresh" ] && pkill -U $USER -x wob
 
 # wob does not appear in $(swaymsg -t get_msg), so:
 is_running_on_this_screen || {
-    tail -f "$wob_pipe" | wob -c $ini &
+    tail -f "$wob_pipe" | wob -c "$effective_ini" &
 }
 
 if [ "$3" = "--refresh" ]; then


### PR DESCRIPTION
## Context

While hunting the regression reported in #973 ("v17.2 broke everything / destroys user settings"), I traced through the theming-config handling. The waybar half of that issue was fixed in 89d82c9a (only `colors.css` is auto-managed; the user's `style.css` is seeded once and left alone), and that fix is still intact. But the **wob** path was never given the same treatment — so this bubbled up out of the investigation as a standalone bug worth fixing regardless of the rest of https://github.com/manjaro-sway/manjaro-sway/issues/973.

## The bug

`wob.sh`'s `refresh()` runs on **every** `swaymsg reload` (via `$onscreen_bar --refresh` in `99-autostart-applications.conf`). It did:

```sh
rm -f $ini            # ~/.config/wob.ini
{ echo "anchor = ..."; echo "margin = ..."; echo "..._color = ..."; } >> $ini
```

So `~/.config/wob.ini` was simultaneously the theme-managed file **and** the file users are expected to customise — every reload wiped their edits (anchor, margin, colors). This matches the wob complaint in https://github.com/manjaro-sway/manjaro-sway/issues/973

## The fix (symmetric with waybar)

- **`~/.config/wob.colors.ini`** — theme-managed, regenerated on every theme switch (analog of waybar's `colors.css`).
- **`~/.config/wob.ini`** — seeded **once**, then never touched (analog of `style.css`), marked with a `# managed by manjaro-sway` header.
- The config handed to `wob -c` is a cache file = managed colors **followed by** the user file, so anything set in `wob.ini` overrides the theme. `--refresh` still restarts wob so new theme colors take effect.
- **Migration:** an existing auto-generated `wob.ini` (no marker, contains `bar_color`) is moved to `wob.ini.bak` once, so its baked-in colors stop shadowing the theme. Backup means no data loss for anyone who hand-edited it.

Also: dropped the non-POSIX `local` (script is `#!/usr/bin/env sh`) and corrected the colour-format comment to `RRGGBB[AA]` (per `wob.ini(5)` the alpha is optional).

## Testing

Sandbox-tested (stubbed `wob`/`pkill`/`pgrep`/`tail`, fake `$SWAYSOCK`):

- Fresh user → colors managed, `wob.ini` seeded with structural defaults only.
- User edits to `wob.ini` survive `--refresh`; theme colors still update; user settings win in the merged config.
- Volume value-push doesn't block and doesn't alter user files.
- Legacy `wob.ini` migrated to `.bak`, reseeded clean, theme color applied with no shadow.
- Repeated `--refresh` is idempotent (no repeated `.bak`, user file untouched).

Refs #973